### PR TITLE
add intake catalog and readme

### DIFF
--- a/dataset_catalog/README.md
+++ b/dataset_catalog/README.md
@@ -1,0 +1,51 @@
+# hytest-catalogs
+This directory holds the `hytest_intake_catalog.yml`. This catalog is structured to be compatible with the Python intake package and facilitates reading the data into the other notebooks contained in this repository. Example usage of this catalog is shown below.
+
+Please note that this catalog is a temporary solution for reading data into our workflows. By the end of 2022, we hope to replace this catalog by a [STAC](https://stacspec.org/en). We plan to update all notebooks to read from our STAC at that time, as well.
+
+```python
+import intake
+url = 'https://raw.githubusercontent.com/USGS-python/hytest-catalogs/main/hytest_intake_catalog.yml'
+cat = intake.open_catalog(url)
+list(cat)
+```
+produces a list of datasets, for example:
+```
+['conus404-40year-onprem',
+ 'conus404-2017-onprem',
+ 'conus404-2017-cloud',
+ 'nwis-streamflow-usgs-gages-onprem',
+ 'nwis-streamflow-usgs-gages-cloud',
+ 'nwm21-streamflow-usgs-gages-onprem',
+ 'nwm21-streamflow-usgs-gages-cloud',
+ 'nwm21-streamflow-cloud',
+ 'nwm21-scores',
+ 'lcmap-cloud']
+ ```
+ The characteristics of indivdual datasets can be explored:
+```python
+cat['lcmap-cloud']
+```
+producing
+```yaml
+lcmap-cloud:
+  args:
+    consolidated: false
+    storage_options:
+      fo: s3://nhgf-development/lcmap/lcmap.json
+      remote_options:
+        requester_pays: true
+      remote_protocol: s3
+      target_options:
+        requester_pays: true
+    urlpath: reference://
+  description: LCMAP, all 36 years
+  driver: intake_xarray.xzarr.ZarrSource
+  metadata:
+    catalog_dir: https://raw.githubusercontent.com/USGS-python/hytest-catalogs/main
+ ```
+ and xarray-type datasets can be loaded with `to_dask()`, while panda-type datasets can be loaded with `.read()`:
+```python
+ds = cat['lcmap-cloud'].to_dask()
+df = cat['nwm21-scores'].read()
+```

--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -1,0 +1,85 @@
+sources:
+  
+  conus404-40year-onprem:
+    driver: zarr
+    description: "CONUS404 Hydro Variable subset, 40 years on Caldera on prem storage"
+    args:
+      urlpath: '/caldera/projects/usgs/water/wbeep/conus404_work/zarr_out/conus404_whole.zarr/'
+      consolidated: true  
+  
+  conus404-2017-onprem:
+    driver: zarr
+    description: "CONUS404 Hydro Variable subset, water year 2017 on Caldera on prem storage"
+    args:
+      urlpath: '/caldera/projects/usgs/hazards/cmgp/woodshole/rsignell/zarr/conus404_2017/'
+      consolidated: true
+
+  conus404-2017-cloud:
+    driver: zarr
+    description: "CONUS404 Hydro Variable subset, water year 2017 on AWS S3 cloud storage"
+    args:
+      urlpath: 's3://esip-qhub/usgs/conus404/hydro_vars/2017' 
+      consolidated: true
+      storage_options:
+        requester_pays: true
+        
+  nwis-streamflow-usgs-gages-onprem:
+    driver: zarr
+    description: "Streamflow from NWIS, extracted and rechunked into time series (NWM2.1 time period)"
+    args:
+      urlpath: '/caldera/projects/usgs/hazards/cmgp/woodshole/rsignell/conus404/zarr/nwis_chanobs.zarr'
+      consolidated: true
+      
+  nwis-streamflow-usgs-gages-cloud:
+    driver: zarr
+    description: "Streamflow from NWIS, extracted and rechunked into time series (NWM2.1 time period)"
+    args:
+      urlpath: 's3://nhgf-development/nwm/nwis_chanobs.zarr'
+      consolidated: true
+      storage_options:
+        requester_pays: true
+      
+  nwm21-streamflow-usgs-gages-onprem:
+    driver: zarr
+    description: "Streamflow from NWM2.1, extracted and rechunked into time series"
+    args:
+      urlpath: '/caldera/projects/usgs/hazards/cmgp/woodshole/rsignell/conus404/zarr/chanobs.zarr'
+      consolidated: true
+      
+  nwm21-streamflow-usgs-gages-cloud:
+    driver: zarr
+    description: "Streamflow from NWM2.1, extracted and rechunked into time series"
+    args:
+      urlpath: 's3://nhgf-development/nwm/chanobs.zarr'
+      consolidated: true
+      storage_options:
+        requester_pays: true
+      
+  nwm21-streamflow-cloud:
+    driver: zarr
+    description: "National Water Model 2.1 CHRTOUT on AWS"
+    args:
+      urlpath: 's3://noaa-nwm-retrospective-2-1-zarr-pds/chrtout.zarr' 
+      consolidated: true
+      storage_options:
+        anon: true
+        
+  nwm21-scores:
+    description: US state information from [CivilServices](https://civil.services/)
+    driver: csv
+    args:
+      urlpath: 'https://raw.githubusercontent.com/nhm-usgs/data-pipeline-helpers/main/hytest/results/nwm_ref_gages_assessment.csv'
+
+  lcmap-cloud:
+    driver: intake_xarray.xzarr.ZarrSource
+    description: 'LCMAP, all 36 years'
+    args:
+      urlpath: "reference://"
+      consolidated: false
+      storage_options:
+        target_options:
+          requester_pays: true
+        fo: 's3://nhgf-development/lcmap/lcmap.json'
+        remote_options:
+          requester_pays: true
+        remote_protocol: s3


### PR DESCRIPTION
This pull request transfers over the contents of https://github.com/USGS-python/hytest-catalogs.

- I updated the `README.md` to delete the disclaimer at the end, and added a few sentences to give context at the beginning.
- I made no changes to the intake catalog
- I did not transfer the [ioos_intake_catalog.yml](https://github.com/USGS-python/hytest-catalogs/blob/main/ioos_intake_catalog.yml) or the [LICENSE](https://github.com/USGS-python/hytest-catalogs/blob/main/LICENSE) (because we have a license for the whole repo in another pull request).

Once we merge this pull request, I will make sure the notebooks in other repos on `USGS-python` get updated to read from this catalog (as I transfer them over to this new repo). Then I will make the `hytest-catalogs` repository private.