### PR TITLE
initial commit of dataset preprocessing notebooks

### DIFF
--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/conus404_daily_rechunk_ja.py
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/conus404_daily_rechunk_ja.py
@@ -1,0 +1,429 @@
+#!/usr/bin/env python
+
+# import numpy as np
+import os
+import argparse
+import dask
+import datetime
+import fsspec
+# import numpy as np
+import pandas as pd
+import rechunker
+import time
+import xarray as xr
+import zarr
+
+from dask.distributed import Client
+
+
+def build_filelist(num_days, c_start, wrf_dir):
+    job_files = []
+
+    for dd in range(num_days):
+        cdate = c_start + datetime.timedelta(days=dd)
+
+        wy_dir = f'WY{cdate.year}'
+        if cdate >= datetime.datetime(cdate.year, 10, 1):
+            wy_dir = f'WY{cdate.year+1}'
+
+        # wrfxtrm_d01_2020-10-01_00:00:00
+        file_pat = f'{wrf_dir}/{wy_dir}/wrfxtrm_d01_{cdate.strftime("%Y-%m-%d_%H:%M:%S")}'
+
+        if not os.path.isfile(file_pat):
+            break
+        job_files.append(file_pat)
+
+    return job_files
+
+
+def read_metadata(filename):
+    # Read the metadata information file
+    fhdl = open(filename, 'r')   # , encoding='ascii')
+    rawdata = fhdl.read().splitlines()
+    fhdl.close()
+
+    it = iter(rawdata)
+    next(it)   # Skip header
+
+    var_metadata = {}
+    for row in it:
+        flds = row.split('\t')
+        var_metadata[flds[0]] = {}
+
+        if len(flds[1]) > 0:
+            var_metadata[flds[0]]['long_name'] = flds[1]
+
+            # if len(flds[3]) > 0:
+            #     var_metadata[flds[0]]['integration_length'] = flds[3]
+        # if len(flds[8]) > 0:
+        #     var_metadata[flds[0]]['standard_name'] = flds[8]
+    return var_metadata
+
+
+def apply_metadata(ds, rename_dims, rename_vars, remove_attrs, var_metadata):
+    avail_dims = ds.dims.keys()
+    rename_dims_actual = {}
+
+    # Only change dimensions that exist in dataset
+    for kk, vv in rename_dims.items():
+        if kk != 'Time' and kk in avail_dims:
+            rename_dims_actual[kk] = vv
+
+    ds = ds.rename(rename_dims_actual)
+
+    # The daily wrfxtrm files lack the XTIME variable but does have
+    # the Times variable with the time as a string; create the time
+    # coordinate variable from this.
+
+    t_str = ds['Times'].values
+    new_times = [datetime.datetime.strptime(tt.tobytes().decode('ascii'), '%Y-%m-%d_%H:%M:%S') for tt in t_str]
+
+    ds['time'] = (('Time'), new_times)
+    ds = ds.rename({'Time': 'time'})
+    ds = ds.assign_coords({'time': ds.time})
+    ds = ds.drop('Times')
+
+    # Modify the attributes
+    for cvar in ds.variables:
+        # Remove unneeded attributes, update the coordinates attribute
+        for cattr in list(ds[cvar].attrs.keys()):
+            if cattr in remove_attrs:
+                del ds[cvar].attrs[cattr]
+
+            if cattr == 'coordinates':
+                # Change the coordinates attribute to new lat/lon naming
+                orig_coords = ds[cvar].attrs[cattr]
+                new_coords = []
+
+                for xx in orig_coords.split(' '):
+                    if xx not in rename_vars:
+                        continue
+                    new_coords.append(rename_vars[xx])
+                ds[cvar].attrs[cattr] = ' '.join(new_coords)
+
+        # Apply the new metadata
+        if cvar in var_metadata:
+            for kk, vv in var_metadata[cvar].items():
+                ds[cvar].attrs[kk] = vv
+
+    return ds
+
+
+def rechunker_wrapper(source_store, target_store, temp_store, chunks=None,
+                      mem=None, consolidated=False, verbose=True):
+    if isinstance(source_store, xr.Dataset):
+        g = source_store  # trying to work directly with a dataset
+        ds_chunk = g
+    else:
+        g = zarr.group(str(source_store))
+        # get the correct shape from loading the store as xr.dataset and parse the chunks
+        ds_chunk = xr.open_zarr(str(source_store))
+
+    group_chunks = {}
+    # newer tuple version that also takes into account when specified chunks are larger than the array
+    for var in ds_chunk.variables:
+        # Pick appropriate chunks from above, and default to full length chunks for
+        # dimensions that are not in `chunks` above.
+        group_chunks[var] = []
+        for di in ds_chunk[var].dims:
+            if di in chunks.keys():
+                if chunks[di] > len(ds_chunk[di]):
+                    group_chunks[var].append(len(ds_chunk[di]))
+                else:
+                    group_chunks[var].append(chunks[di])
+
+            else:
+                group_chunks[var].append(len(ds_chunk[di]))
+
+        group_chunks[var] = tuple(group_chunks[var])
+    if verbose:
+        print(f"Rechunking to: {group_chunks}")
+        print(f"mem:{mem}")
+    rechunked = rechunker.rechunk(g, target_chunks=group_chunks, max_mem=mem,
+                                  target_store=target_store, temp_store=temp_store)
+    rechunked.execute(retries=10)
+    if consolidated:
+        if verbose:
+            print('consolidating metadata')
+        zarr.convenience.consolidate_metadata(target_store)
+    if verbose:
+        print('done')
+
+
+def set_file_path(path1, path2=None):
+    '''Helper function to check/set the full path to a file.
+       path1 should include a filename
+       path2 should only be a directory'''
+
+    file_path = None
+
+    if os.path.isfile(path1):
+        # File exists, use the supplied path
+        file_path = os.path.realpath(path1)
+    else:
+        # file does not exist
+        if path2:
+            file_path = os.path.realpath(f'{path2}/{path1}')
+
+            if os.path.isfile(file_path):
+                # File exists in path2 so append it to the path
+                print(f'Using filepath, {file_path}')
+            else:
+                raise FileNotFoundError(f'File, {path1}, does not exist in {path2}')
+        else:
+            raise FileNotFoundError(f'File, {path1}, does not exist')
+
+    return file_path
+
+
+def set_target_path(path, base_dir=None, verbose=False):
+    new_path = None
+
+    if os.path.isdir(path):
+        # We're good, use it
+        new_path = os.path.realpath(path)
+        if verbose:
+            print(f'{new_path} exists.')
+    else:
+        # path is not a directory, does the parent directory exist?
+        pdir = os.path.dirname(path)
+
+        if pdir == '':
+            # There is no parent directory, try using base_dir if it exists
+            if base_dir:
+                # create/use
+                if not os.path.isdir(base_dir):
+                    raise FileNotFoundError(f'Base directory, {base_dir}, does not exist')
+
+                new_path = f'{base_dir}/{path}'
+
+                if os.path.isdir(new_path):
+                    if verbose:
+                        print(f'Using existing target path, {new_path}')
+                else:
+                    os.mkdir(new_path)
+
+                    if verbose:
+                        print(f'Creating target relative to base directory, {new_path}')
+            else:
+                # No base_dir supplied; create target path in current directory
+                new_path = os.path.realpath(path)
+                os.mkdir(new_path)
+
+                if verbose:
+                    print(f'Target path, {new_path}, created')
+        elif os.path.isdir(pdir):
+            # Parent path exists we just need to create the child directory
+            new_path = os.path.realpath(path)
+            os.mkdir(new_path)
+
+            if verbose:
+                print(f'Parent, {pdir}, exists. Created {new_path} directory')
+        else:
+            # print(f'ERROR: Parent of target path does not exist.')
+            raise FileNotFoundError(f'Parent, {pdir}, of target path, {path}, does not exist')
+
+    return new_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create cloud-optimized zarr files from WRF CONUS404 daily model output files')
+    parser.add_argument('-i', '--index', help='Index to process', required=True)
+    parser.add_argument('-b', '--base_dir', help='Directory to work in', required=False, default=None)
+    parser.add_argument('-w', '--wrf_dir', help='Base directory for WRF model output files', required=True)
+    parser.add_argument('-c', '--constants_file', help='Path to WRF constants', required=False, default=None)
+    parser.add_argument('-v', '--vars_file', help='File containing list of variables to include in output', required=True)
+    parser.add_argument('-d', '--dst_dir', help='Location to store rechunked zarr files', required=True)
+    parser.add_argument('-m', '--metadata_file', help='File containing metadata to include in zarr files', required=True)
+
+    args = parser.parse_args()
+
+    print(f'HOST: {os.environ.get("HOSTNAME")}')
+    if os.environ.get('HOSTNAME') == 'denali-login2':
+        exit(-1)
+
+    index_start = int(args.index)
+    print(f'{index_start=}')
+
+    base_dir = os.path.realpath(args.base_dir)
+    wrf_dir = os.path.realpath(args.wrf_dir)
+
+    const_file = set_file_path(args.constants_file, base_dir)
+    metadata_file = set_file_path(args.metadata_file, base_dir)
+    proc_vars_file = set_file_path(args.vars_file, base_dir)
+    target_store = f'{set_target_path(args.dst_dir, base_dir)}/target'
+
+    print(f'{base_dir=}')
+    print(f'{wrf_dir=}')
+    print(f'{const_file=}')
+    print(f'{metadata_file=}')
+    print(f'{proc_vars_file=}')
+    print(f'{target_store=}')
+    print('-'*60)
+
+    temp_store = '/dev/shm/tmp'
+    base_date = datetime.datetime(1979, 10, 1)
+    num_days = 24
+    delta = datetime.timedelta(days=num_days)
+
+    # We specify a chunk index and the start date is selected based on that
+    index_start = int(args.index)
+    st_date = base_date + datetime.timedelta(days=num_days * index_start)
+    en_date = st_date + delta - datetime.timedelta(days=1)
+    print(f'{index_start=}')
+
+    print(f'{base_date=}')
+    print(f'{st_date=}')
+    print(f'{en_date=}')
+    print(f'{num_days=}')
+    print(f'{delta=}')
+
+    if (st_date - base_date).days % num_days != 0:
+        print(f'Start date must begin at the start of a {num_days}-day chunk')
+
+    # index_start = int((st_date - base_date).days / num_days)
+    print(f'{index_start=}')
+    print('-'*60)
+
+    time_chunk = num_days
+    x_chunk = 350
+    y_chunk = 350
+
+    # Variables to drop from the constants file
+    drop_vars = ['BF', 'BH', 'C1F', 'C1H', 'C2F', 'C2H', 'C3F', 'C3H', 'C4F', 'C4H',
+                 'CF1', 'CF2', 'CF3', 'CFN', 'CFN1', 'CLAT', 'COSALPHA', 'DN', 'DNW',
+                 'DZS', 'E', 'F', 'FNM', 'FNP', 'HGT', 'ISLTYP', 'IVGTYP', 'LAKEMASK',
+                 'LU_INDEX', 'MAPFAC_M', 'MAPFAC_MX', 'MAPFAC_MY',
+                 'MAPFAC_U', 'MAPFAC_UX', 'MAPFAC_UY', 'MAPFAC_V', 'MAPFAC_VX', 'MAPFAC_VY',
+                 'MAX_MSTFX', 'MAX_MSTFY', 'MF_VX_INV', 'MUB', 'P00', 'PB', 'PHB',
+                 'P_STRAT', 'P_TOP', 'RDN', 'RDNW', 'RDX', 'RDY', 'SHDMAX', 'SHDMIN',
+                 'SINALPHA', 'SNOALB', 'T00', 'TISO', 'TLP', 'TLP_STRAT', 'VAR',
+                 'VAR_SSO', 'XLAND', 'XLAT_U', 'XLAT_V', 'XLONG_U', 'XLONG_V',
+                 'ZETATOP', 'ZNU', 'ZNW', 'ZS']
+
+    # Attributes that should be removed from all variables
+    remove_attrs = ['FieldType', 'MemoryOrder', 'stagger', 'cell_methods']
+
+    rename_dims = {'south_north': 'y', 'west_east': 'x', 'Time': 'time'}
+
+    rename_vars = {'XLAT': 'lat', 'XLONG': 'lon',
+                   'south_north': 'y', 'west_east': 'x'}
+
+    # Read the metadata file for modifications to variable attributes
+    var_metadata = read_metadata(metadata_file)
+
+    # Add additional time attributes
+    var_metadata['time'] = dict(axis='T', standard_name='time')
+
+    # Start up the cluster
+    client = Client(n_workers=8, threads_per_worker=1, memory_limit='24GB')
+
+    print(f'dask tmp directory: {dask.config.get("temporary-directory")}')
+
+    # Max total memory in gigabytes for cluster
+    total_mem = sum(vv['memory_limit'] for vv in client.scheduler_info()['workers'].values()) / 1024**3
+    total_threads = sum(vv['nthreads'] for vv in client.scheduler_info()['workers'].values())
+    print(f'Total memory: {total_mem:0.1f} GB')
+    print(f'Number of threads: {total_threads}')
+
+    # Maximum percentage of memory to use for rechunking per thread
+    max_percent = 0.7
+
+    max_mem = f'{total_mem / total_threads * max_percent:0.0f}GB'
+    print(f'Maximum memory per thread for rechunking: {max_mem}')
+    print('='*60)
+
+    # Read variables to process
+    df = pd.read_csv(proc_vars_file)
+
+    fs = fsspec.filesystem('file')
+
+    start = time.time()
+
+    cnk_idx = index_start
+    c_start = st_date
+
+    while c_start < en_date:
+        job_files = build_filelist(num_days, c_start, wrf_dir)
+
+        if len(job_files) < num_days:
+            print(f'Number of files not equal to time chunk; adjusting to {len(job_files)}')
+            num_days = len(job_files)
+            time_chunk = num_days
+
+        tstore_dir = f'{target_store}_{cnk_idx:05d}'
+        # num_time = len(job_files)
+
+        # =============================================
+        # Do some work here
+        var_list = df['variable'].to_list()
+        var_list.append('time')
+
+        # rechunker requires empty tmp and target dirs
+        try:
+            fs.rm(temp_store, recursive=True)
+        except:
+            pass
+        try:
+            fs.rm(tstore_dir, recursive=True)
+        except:
+            pass
+
+        time.sleep(3)  # wait for files to be removed (necessary? hack!)
+
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~
+        # Open netcdf source files
+        t1 = time.time()
+        ds2d = xr.open_mfdataset(job_files, concat_dim='Time', combine='nested',
+                                 parallel=True, coords="minimal", data_vars="minimal",
+                                 compat='override', chunks={})
+
+        if cnk_idx == 0:
+            # Add the wrf constants during the first time chunk
+            df_const = xr.open_dataset(const_file, chunks={})
+            df_const = df_const.drop_vars(drop_vars, errors='ignore')
+
+            ds2d = ds2d.merge(df_const)
+            ds2d = ds2d.rename(rename_vars)
+
+            for vv in df_const.variables:
+                if vv in rename_vars:
+                    var_list.append(rename_vars[vv])
+                else:
+                    var_list.append(vv)
+            df_const.close()
+
+        ds2d = apply_metadata(ds2d, rename_dims, rename_vars, remove_attrs, var_metadata)
+        print(f'    Open mfdataset: {time.time() - t1:0.3f} s')
+
+        t1 = time.time()
+        rechunker_wrapper(ds2d[var_list], target_store=tstore_dir, temp_store=temp_store,
+                          mem=max_mem, consolidated=True, verbose=False,
+                          chunks={'time': time_chunk,
+                                  'y': y_chunk, 'x': x_chunk,
+                                  'y_stag': y_chunk, 'x_stag': x_chunk})
+        print(f'    rechunker: {time.time() - t1:0.3f} s')
+
+        end = time.time()
+        print(f'Chunk: {cnk_idx}, elapsed time: {(end - start) / 60.:0.3f}, {job_files[0]}')
+
+        cnk_idx += 1
+        c_start += delta
+
+    client.close()
+    
+    # Clear out the temporary storage
+    try:
+        fs.rm(temp_store, recursive=True)
+    except:
+        pass
+
+    if dask.config.get("temporary-directory") == '/dev/shm':
+        try:
+            fs.rm(f'/dev/shm/dask-worker-space', recursive=True)
+        except:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/conus404_to_zarr_daily.py
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/conus404_to_zarr_daily.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python
+
+import argparse
+import dask
+import fsspec
+import pandas as pd
+import os
+import time
+import xarray as xr
+
+from dask.distributed import Client
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create cloud-optimized zarr files from WRF CONUS404')
+    parser.add_argument('-i', '--index', help='Index to process', type=int, required=True)
+    parser.add_argument('-s', '--step', help='Number of indices to process from start index', type=int, required=True)
+    parser.add_argument('-b', '--base_dir', help='Directory to work in', required=False, default=None)
+    parser.add_argument('-d', '--dst_dir', help='Location to store file zarr file', required=True)
+    parser.add_argument('-z', '--zarr_dir', help='Location of source zarr files', required=True)
+
+    args = parser.parse_args()
+
+    first_idx = args.index
+    idx_span = args.step
+    last_idx = first_idx + idx_span
+
+    base_dir = os.path.realpath(args.base_dir)
+    outzarr_dir = os.path.realpath(args.dst_dir)
+
+    src_zarr = os.path.realpath(f'{args.zarr_dir}/target_*')
+
+    zarr_whole = f'{outzarr_dir}/conus404_daily.zarr'
+
+    print(f'{first_idx=}')
+    print(f'{idx_span=}')
+    print(f'{last_idx=}')
+    print('-'*60)
+    print(f'{base_dir=}')
+    print(f'{outzarr_dir=}')
+    print(f'{src_zarr=}')
+    print(f'{zarr_whole=}')
+
+    time_cnk = 24
+
+    fs = fsspec.filesystem('file')
+    zlist = sorted(fs.glob(src_zarr))
+    num_targets = len(zlist)
+
+    if num_targets < last_idx - 1:
+        idx_span = num_targets - first_idx
+        last_idx = first_idx + idx_span
+        print(f'NOTE: Adjusted processing indices')
+
+    print(f'Index start: {first_idx}; Index end: {last_idx - 1}')
+
+    # Start up the cluster
+    # client = Client(n_workers=8, threads_per_worker=1, memory_limit='24GB')
+    client = Client()
+
+    print(f'dask tmp directory: {dask.config.get("temporary-directory")}')
+
+    # Max total memory in gigabytes for cluster
+    total_mem = sum(vv['memory_limit'] for vv in client.scheduler_info()['workers'].values()) / 1024**3
+    total_threads = sum(vv['nthreads'] for vv in client.scheduler_info()['workers'].values())
+    print(f'Total memory: {total_mem:0.1f} GB')
+    print(f'Number of threads: {total_threads}')
+
+    t1_proc = time.time()
+    if first_idx == 0:
+        # Open first and last zarr file to get date range
+        ds0 = xr.open_dataset(zlist[0], engine='zarr', chunks={})
+        ds1 = xr.open_dataset(zlist[-1], engine='zarr', chunks={})
+
+        # TODO: the freq argument must reflect the time interval (e.g hourly, daily)
+        dates = pd.date_range(start=ds0.time[0].values, end=ds1.time[-1].values, freq='1d')
+
+        # Have to drop the constant variables (e.g. variables having no time dimension)
+        drop_vars = ['LANDMASK', 'lat', 'lon', 'x', 'y', 'crs']
+
+        source_dataset = ds0.drop_vars(drop_vars, errors='ignore')
+
+        template = (source_dataset.chunk().pipe(xr.zeros_like).isel(time=0, drop=True).expand_dims(time=len(dates)))
+        template['time'] = dates
+        template = template.chunk({'time': time_cnk})
+
+        # Writes no data (yet)
+        template.to_zarr(zarr_whole, compute=False, consolidated=True, mode='w')
+
+        # Writes the data
+        ds0.drop_vars(drop_vars).to_zarr(zarr_whole, region={'time': slice(0, time_cnk)})
+
+        # Add the wrf constants
+        add_vars = ['LANDMASK', 'lat', 'lon', 'x', 'y', 'crs']
+        ds0[add_vars].to_zarr(zarr_whole, mode='a')
+        print(f'  Index {first_idx} (pre-create output): {time.time() - t1_proc:0.3f} s')
+
+    for i in range(first_idx, last_idx):
+        if i == 0:
+            continue
+        t1 = time.time()
+        start = i * time_cnk
+        stop = (i + 1) * time_cnk
+
+        # print(zlist[i])
+        dsi = xr.open_dataset(zlist[i], engine='zarr', chunks={})
+        dsi.to_zarr(zarr_whole, region={'time': slice(start, stop)})
+        print(f'  Index {i}: {time.time() - t1:0.3f} s')
+
+    client.close()
+    if dask.config.get("temporary-directory") == '/dev/shm':
+        try:
+            fs.rm(f'/dev/shm/dask-worker-space', recursive=True)
+        except:
+            pass
+
+    print(f'Total time: {time.time() - t1_proc:0.3f} s')
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/rechunk_daily.sbatch
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/rechunk_daily.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J rechunk
+#SBATCH -t 00:20:00
+#SBATCH -o %j-rechunk.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=10
+
+export PATH="$PATH:$HOME/miniconda3/bin"
+
+source activate pangeo
+
+base_dir=/caldera/projects/usgs/water/wbeep/conus404_work
+wrf_dir=wrfout_post
+const_file=wrf_constants_conus404_final.nc
+metadata_file=wrfout_metadata_w_std.csv
+proc_vars_file=2022-03-16_DRB_addl_vars.csv
+target_store=/calscratch/global/pnorton_daily_tmp
+
+python /caldera/projects/usgs/water/wbeep/conus404_work/conus404_daily_rechunk_ja.py -i $SLURM_ARRAY_TASK_ID -b $base_dir -w $wrf_dir -c $const_file -v $proc_vars_file -m $metadata_file -d $target_store
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/submit_conus404_processing_daily.sh
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/submit_conus404_processing_daily.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+STEP=10
+MAX_JOBS=30
+
+LAST_STEP=639
+
+#sbatch --array=0-10:10 to_zarr.sbatch
+#sbatch --dependency=afterok:2749205 --array=0-100:10 to_zarr.sbatch
+
+# First rechunk CONUS404 model output
+jobid0=$(sbatch --parsable --array=0-${LAST_STEP}%${MAX_JOBS} rechunk_daily.sbatch)
+
+# Create final ZARR of CONUS404 data
+jobid1=$(sbatch --parsable --dependency=afterok:${jobid0} --array=0-9:${STEP} to_zarr_daily.sbatch)
+sbatch --dependency=afterok:${jobid1} --array=10-${LAST_STEP}:${STEP}%${MAX_JOBS} to_zarr_daily.sbatch

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/to_zarr_daily.sbatch
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/daily/to_zarr_daily.sbatch
@@ -1,0 +1,23 @@
+#!/bin/bash
+#SBATCH -J cat_zarr
+#SBATCH -t 00:20:00
+#SBATCH -o %j-to_zarr.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=40
+
+# STEP should match the stride in the --array argument
+export STEP=10
+export PATH="$PATH:$HOME/miniconda3/bin"
+
+source activate pangeo
+
+base_dir=/caldera/projects/usgs/water/wbeep/conus404_work
+src_zarr_dir=/calscratch/global/pnorton_daily_tmp
+dst_zarr_dir=/caldera/projects/usgs/water/wbeep/conus404_work/zarr_daily_out
+
+echo $SLURM_ARRAY_TASK_ID
+python /caldera/projects/usgs/water/wbeep/conus404_work/conus404_to_zarr_daily.py -i $SLURM_ARRAY_TASK_ID -s $STEP -b $base_dir -z $src_zarr_dir -d $dst_zarr_dir
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_hourly_derived.py
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_hourly_derived.py
@@ -1,0 +1,684 @@
+#!/usr/bin/env python
+
+import argparse
+import dask
+import datetime
+import fsspec
+import numpy as np
+import os
+import rechunker
+import time
+import xarray as xr
+import zarr
+
+from typing import Dict, Optional, Union
+from dask.distributed import Client
+
+
+# ===================================
+# Vapor pressure formulas
+# ===================================
+def vp(qv: Union[float, xr.Dataset, xr.DataArray],
+       pressure: Union[float, xr.Dataset, xr.DataArray]):
+    """Water vapor pressure from mixing ratio and pressure
+
+    :param qv: Water vapor mixing ratio [kg kg-1]
+    :param pressure: Pressure [Pa]
+    """
+
+    # NOTE: Suggested in Milly DRB spreadsheet
+    # NOTE: Suggested for use in WRF forum: https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?t=9134#:~:text=Re%3A%20relative%20humidity&text=The%20Relative%20Humidity%20(RH)%20is,you%20can%20easily%20obtain%20RH.
+    # NOTE: Used by Teten relative humidity formula
+    epsilon = 0.622  # Rd / Rv; []
+
+    e = qv * pressure / (epsilon + qv)
+    return e
+
+
+# ===================================
+# Saturation vapor pressure formulas
+# ===================================
+def saturation_vp_bolton(temperature: Union[float, xr.Dataset, xr.DataArray]):
+    """Saturation vapor pressure from Bolton formula (1980)
+
+    :param temperature: Temperature [K]
+    """
+    # Note: This is the formulation used for sat vp in the relative humidity
+    #       computation suggested in the WRF forum.
+    #       https://forum.mmm.ucar.edu/phpBB3/viewtopic.php?t=9134#:~:text=Re%3A%20relative%20humidity&text=The%20Relative%20Humidity%20(RH)%20is,you%20can%20easily%20obtain%20RH.
+
+    es0 = 611.2   # Sautration vapor pressure reference value; [Pa]
+    svp2 = 17.67
+    svp3 = 29.65
+    svpt0 = 273.15   # [K]
+
+    es = es0 * np.exp(svp2 * (temperature - svpt0) / (temperature - svp3))
+    return es
+
+
+def saturation_vp_magnus(temperature: Union[float, xr.Dataset, xr.DataArray]):
+    """Magnus saturation vapor pressure formula
+
+    :param temperature: Temperature [K]
+    """
+
+    # Lawrence (2005), eqn 6
+    # Relative error less than 0.4% over -40C <= t <= 50C
+
+    c1 = 610.94   # [Pa]
+    a1 = 17.625
+    b1 = 243.04   # [C]
+
+    temp_c = temperature - 273.15
+    es = c1 * np.exp(a1 * temp_c / (b1 + temp_c))
+
+    print(f'{es=}')
+    return es
+
+
+def saturation_vp_teten(temperature: Union[float, xr.Dataset, xr.DataArray]):
+    """Teten's formula for saturation vapor pressure from temperature
+
+    :param temperature: Temperature [K]
+    """
+    es0 = 6.113  # Saturation vapor pressure reference value; [hPa]
+    es0 *= 100   # [Pa]
+
+    temp_c = temperature - 273.15   # [C]
+
+    # Saturation vapor pressure
+    es = es0 * np.exp(17.269 * temp_c / (temp_c + 237.3))   # [Pa]
+    return es
+
+
+# ===================================
+# Relative humidity formulas
+# ===================================
+def rh(qv: Union[float, xr.Dataset, xr.DataArray],
+       pressure: Union[float, xr.Dataset, xr.DataArray],
+       temperature: Union[float, xr.Dataset, xr.DataArray]):
+    """Relative humidity
+
+    :param qv: Water vapor mixing ratio [kg kg-1]
+    :param pressure: Surface pressure [Pa]
+    :param temperature: Temperature [K]
+    """
+
+    # Saturation vapor pressure
+    num1 = temperature - 273.15
+    den1 = temperature - 29.65
+    es = 6.112 * np.exp(17.67 * num1 / den1)   # [Pa]
+
+    # Saturation water vapor mixing ratio
+    num2 = 0.622 * es
+    den2 = 0.01 * pressure - 0.378 * es
+    qvs = num2 / den2
+
+    # Specific humidity
+    sh = qv / qvs
+
+    # Relative humidity
+    return 100 * np.maximum(np.minimum(sh, 1.0), 0.0)
+
+
+def rh_teten(qv: Union[float, xr.Dataset, xr.DataArray],
+             pressure: Union[float, xr.Dataset, xr.DataArray],
+             temperature: Union[float, xr.Dataset, xr.DataArray]):
+    """Relative humidity using Teten's formula
+
+    :param qv: Water vapor mixing ratio [kg kg-1]
+    :param pressure: Surface pressure [Pa]
+    :param temperature: Temperature [K]
+    """
+
+    # Vapor pressure
+    e = vp(qv, pressure)   # [Pa]
+    # e = (qv * pres) / (epsilon + qv)   # [Pa]
+
+    # Saturation vapor pressure
+    es = saturation_vp_teten(temperature)   # [Pa]
+
+    # Relative humidity
+    return 100.0 * (e / es)   # 0-100%
+
+
+# ===================================
+# Specific humidity formulas
+# ===================================
+def specific_humidity(qv: Union[float, xr.Dataset, xr.DataArray]):
+    """Specific humdity from water vapor mixing ratio
+
+    :param qv: Water vapor mixing ratio [kg kg-1]"""
+    return qv / (1 + qv)
+
+
+# def compute_saturation_vp(temperature: Union[float, xr.Dataset, xr.DataArray]):
+#     """Saturation vapor pressure from temperature
+#
+#     :param temperature: Temperature [K]
+#     """
+#     # Compute saturation vapor pressure from T2
+#
+#     # equation from Milly's DRB spreadsheet
+#     return 611 * np.exp(17.269 * (temperature - 273.15) / (temperature - 35.85))
+
+
+# ===================================
+# Dewpoint temperature formulas
+# ===================================
+
+# !!!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!!!
+# !~ from WRF phys/module_diag_functions.F
+# !~ Name:
+# !~    calc_Dewpoint
+# !~
+# !~ Description:
+# !~    This function approximates dewpoint given temperature and rh.
+# !~
+# !!!~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~!!!
+# FUNCTION calc_Dewpoint ( tC, rh) result( Dewpoint )
+#   !~ Variable Declaration
+#   !  --------------------
+#   real, intent ( in ) :: tC
+#   real, intent ( in ) :: rh
+#   real                :: Dewpoint
+#
+#   real :: term, es, e1, e, logs, expon
+#
+#   expon    = ( 7.5*tC ) / ( 237.7+tC )
+#   es       = 6.112 * ( 10**expon )     ! Saturated vapor pressure
+#   e        = es * ( rh/100.0 )         ! Vapor pressure
+#   logs     = LOG10 ( e/6.112 )
+#   Dewpoint = ( 237.7*logs ) / ( 7.5-logs )
+#
+# END FUNCTION calc_Dewpoint
+
+
+def dewpoint_temperature(temperature: Union[float, xr.Dataset, xr.DataArray],
+                         vapor_pressure: Union[float, xr.Dataset, xr.DataArray],
+                         sat_vp: Union[float, xr.Dataset, xr.DataArray]):
+    """Dewpoint temperature
+
+    :param temperature: Temperature [K]
+    :param vapor_pressure: Vapor pressure [Pa]
+    :param sat_vp: Saturation vapor pressure [Pa]
+    """
+
+    #  237.3 * X / ( 17.269 - X ) ;  where X = { ln ( E2 / ESAT2 ) + 17.269 * ( T2 - 273.15 ) / ( T2 - 35.85 ) }
+    # equation from Milly's DRB spreadsheet
+    x = np.log(vapor_pressure / sat_vp) + 17.269 * (temperature - 273.15) / (temperature - 35.85)
+    return 237.3 * x / (17.269 - x)
+
+
+def dewpoint_temperature_magnus(qv: Union[float, xr.Dataset, xr.DataArray],
+                                pressure: Union[float, xr.Dataset, xr.DataArray]):
+    """Dewpoint temperature based on Magnus formula
+
+    :param qv: Water vapor mixing ratio [kg kg-1]
+    :param pressure: Pressure [Pa]
+    """
+
+    # Lawrence (2005), eqn 7
+    c1 = 610.94   # [Pa]
+    a1 = 17.625
+    b1 = 243.04   # [C]
+
+    # Vapor pressure
+    e = vp(qv, pressure)
+
+    # Dewpoint temperature
+    return (b1 * np.log(e / c1)) / (a1 - np.log(e / c1)) + 273.15   # [K]
+
+
+def read_metadata(filename: str):
+    """Read the metadata information file
+
+    :param filename: Path to metadata file
+    """
+
+    fhdl = open(filename, 'r')   # , encoding='ascii')
+    rawdata = fhdl.read().splitlines()
+    fhdl.close()
+
+    it = iter(rawdata)
+    next(it)   # Skip header
+
+    var_metadata = {}
+    for row in it:
+        flds = row.split('\t')
+        var_metadata[flds[0]] = {}
+
+        if len(flds[1]) > 0:
+            var_metadata[flds[0]]['long_name'] = flds[1]
+
+        if len(flds[3]) > 0:
+            var_metadata[flds[0]]['integration_length'] = flds[3]
+        # if len(flds[8]) > 0:
+        #     var_metadata[flds[0]]['standard_name'] = flds[8]
+    return var_metadata
+
+
+def apply_metadata(ds, rename_dims, rename_vars, remove_attrs, var_metadata):
+    avail_dims = ds.dims.keys()
+    rename_dims_actual = {}
+
+    # Only change dimensions that exist in dataset
+    for kk, vv in rename_dims.items():
+        if kk in avail_dims:
+            rename_dims_actual[kk] = vv
+
+    ds = ds.rename(rename_dims_actual)
+    ds = ds.assign_coords({'time': ds.XTIME})
+
+    # Modify the attributes
+    for cvar in ds.variables:
+        # Remove unneeded attributes, update the coordinates attribute
+        for cattr in list(ds[cvar].attrs.keys()):
+            if cattr in remove_attrs:
+                del ds[cvar].attrs[cattr]
+
+            if cattr == 'coordinates':
+                # Change the coordinates attribute to new lat/lon naming
+                orig_coords = ds[cvar].attrs[cattr]
+                new_coords = []
+                for xx in orig_coords.split(' '):
+                    if xx not in rename_vars:
+                        continue
+                    new_coords.append(rename_vars[xx])
+                ds[cvar].attrs[cattr] = ' '.join(new_coords)
+
+        # Apply the new metadata
+        if cvar in var_metadata:
+            for kk, vv in var_metadata[cvar].items():
+                ds[cvar].attrs[kk] = vv
+
+    return ds
+
+
+def rechunker_wrapper(source_store: Union[xr.Dataset, xr.DataArray], target_store: str, temp_store: str,
+                      chunks: Optional[Dict[str, int]] = None, mem: Optional[str] = None,
+                      consolidated: Optional[bool] = False, verbose: Optional[bool] = True):
+    """Rechunk a given xarray dataset and store in the zarr format.
+
+    :param source_store: xarray dataset or path to dataset to rechunk
+    :param target_store: Path to store rechunked dataset to
+    :param temp_store: Path to temporary storage used during the rechunk process
+    :param chunks: Dictionary of chunks to use for dimensions
+    :param mem: Maximum amount of memory available for rechunking
+    :param consolidated: If true consolidates the metadata for the final zarr object
+    :param verbose: If true output additional information
+    """
+    if isinstance(source_store, xr.Dataset):
+        g = source_store  # trying to work directly with a dataset
+        ds_chunk = g
+    else:
+        g = zarr.group(str(source_store))
+        # get the correct shape from loading the store as xr.dataset and parse the chunks
+        ds_chunk = xr.open_zarr(str(source_store))
+
+    group_chunks = {}
+    # newer tuple version that also takes into account when specified chunks are larger than the array
+    for var in ds_chunk.variables:
+        # Pick appropriate chunks from above, and default to full length chunks for
+        # dimensions that are not in `chunks` above.
+        group_chunks[var] = []
+        for di in ds_chunk[var].dims:
+            if di in chunks.keys():
+                if chunks[str(di)] > len(ds_chunk[di]):
+                    group_chunks[var].append(len(ds_chunk[di]))
+                else:
+                    group_chunks[var].append(chunks[str(di)])
+
+            else:
+                group_chunks[var].append(len(ds_chunk[di]))
+
+        group_chunks[var] = tuple(group_chunks[var])
+
+    if verbose:
+        print(f"Rechunking to: {group_chunks}")
+        print(f"mem:{mem}")
+
+    rechunked = rechunker.rechunk(g, target_chunks=group_chunks, max_mem=mem,
+                                  target_store=target_store, temp_store=temp_store)
+    rechunked.execute(retries=10)
+
+    if consolidated:
+        if verbose:
+            print('consolidating metadata')
+        zarr.convenience.consolidate_metadata(target_store)
+
+    if verbose:
+        print('done')
+
+
+def set_file_path(path1: str, path2: Optional[str] = None):
+    """Helper function to check/set the full path to a file.
+
+    :param path1: Absolute or relative path to a file (must include filename)
+    :param path2: Optional path to use when path1 is a filename
+    """
+
+    # file_path = None
+
+    if os.path.isfile(path1):
+        # File exists, use the supplied path
+        file_path = os.path.realpath(path1)
+    else:
+        # file does not exist
+        if path2:
+            file_path = os.path.realpath(f'{path2}/{path1}')
+
+            if os.path.isfile(file_path):
+                # File exists in path2 so append it to the path
+                print(f'Using filepath, {file_path}')
+            else:
+                raise FileNotFoundError(f'File, {path1}, does not exist in {path2}')
+        else:
+            raise FileNotFoundError(f'File, {path1}, does not exist')
+
+    return file_path
+
+
+def set_target_path(path: str, base_dir: Optional[str] = None, verbose: Optional[bool] = False):
+    if os.path.isdir(path):
+        # We're good, use it
+        new_path = os.path.realpath(path)
+        if verbose:
+            print(f'{new_path} exists.')
+    else:
+        # path is not a directory, does the parent directory exist?
+        pdir = os.path.dirname(path)
+
+        if pdir == '':
+            # There is no parent directory, try using base_dir if it exists
+            if base_dir:
+                # create/use
+                if not os.path.isdir(base_dir):
+                    raise FileNotFoundError(f'Base directory, {base_dir}, does not exist')
+
+                new_path = f'{base_dir}/{path}'
+
+                if os.path.isdir(new_path):
+                    if verbose:
+                        print(f'Using existing target path, {new_path}')
+                else:
+                    os.mkdir(new_path)
+
+                    if verbose:
+                        print(f'Creating target relative to base directory, {new_path}')
+            else:
+                # No base_dir supplied; create target path in current directory
+                new_path = os.path.realpath(path)
+                os.mkdir(new_path)
+
+                if verbose:
+                    print(f'Target path, {new_path}, created')
+        elif os.path.isdir(pdir):
+            # Parent path exists we just need to create the child directory
+            new_path = os.path.realpath(path)
+            os.mkdir(new_path)
+
+            if verbose:
+                print(f'Parent, {pdir}, exists. Created {new_path} directory')
+        else:
+            # print(f'ERROR: Parent of target path does not exist.')
+            raise FileNotFoundError(f'Parent, {pdir}, of target path, {path}, does not exist')
+
+    return new_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create cloud-optimized zarr files for CONUS404 derived variables')
+    parser.add_argument('-i', '--index', help='Index to process', type=int, required=True)
+    parser.add_argument('-b', '--base_dir', help='Directory to work in', required=False, default=None)
+    # parser.add_argument('-w', '--wrf_dir', help='Base directory for WRF model output files', required=True)
+    # parser.add_argument('-c', '--constants_file', help='Path to WRF constants', required=False, default=None)
+    # parser.add_argument('-v', '--vars_file', help='File containing list of variables to include in output',
+    #                     required=True)
+    parser.add_argument('-d', '--dst_dir', help='Location to store rechunked zarr files', required=True)
+    # parser.add_argument('-m', '--metadata_file', help='File containing metadata to include in zarr files',
+    #                     required=True)
+    parser.add_argument('-s', '--src_zarr', help='Path to source zarr dataset', required=True)
+    parser.add_argument('--step', help='Number of indices to process from start index', type=int, default=1)
+
+    args = parser.parse_args()
+
+    print(f'HOST: {os.environ.get("HOSTNAME")}')
+    print(f'SLURMD_NODENAME: {os.environ.get("SLURMD_NODENAME")}')
+    # if os.environ.get('HOSTNAME') == 'denali-login2':
+    #     exit(-1)
+
+    base_dir = os.path.realpath(args.base_dir)
+    # wrf_dir = os.path.realpath(args.wrf_dir)
+
+    # const_file = set_file_path(args.constants_file, base_dir)
+    # metadata_file = set_file_path(args.metadata_file, base_dir)
+    # proc_vars_file = set_file_path(args.vars_file, base_dir)
+    target_store = f'{set_target_path(args.dst_dir, base_dir)}/target'
+    zarr_store = f'{set_target_path(args.src_zarr, base_dir)}'
+
+    print(f'{base_dir=}')
+    # print(f'{wrf_dir=}')
+    # print(f'{const_file=}')
+    # print(f'{metadata_file=}')
+    # print(f'{proc_vars_file=}')
+    print(f'{target_store=}')
+    print(f'{zarr_store=}')
+    print('-'*60)
+
+    temp_store = '/dev/shm/tmp'
+    base_date = datetime.datetime(1979, 10, 1)
+    num_days = 6
+    delta = datetime.timedelta(days=num_days)
+
+    # We specify a chunk index and the start date is selected based on that
+    index_start = args.index
+    index_span = args.step
+    index_end = index_start + index_span
+
+    st_date = base_date + datetime.timedelta(days=num_days * index_start)
+
+    # NOTE: en_date changed from processing a single zarr chunk to processing
+    #       all zarr chunks
+    en_date = datetime.datetime(2020, 9, 30)
+    # en_date = st_date + delta - datetime.timedelta(days=1)
+    print(f'{index_start=}')
+
+    print(f'{base_date=}')
+    print(f'{st_date=}')
+    print(f'{en_date=}')
+    print(f'{num_days=}')
+    print(f'{delta=}')
+
+    # if st_date.month != base_date.month or st_date.day != base_date.day:
+    if (st_date - base_date).days % num_days != 0:
+        print(f'Start date must begin at the start of a {num_days}-day chunk')
+
+    # index_start = int((st_date - base_date).days / num_days)
+    print(f'{index_start=}')
+    print('-'*60)
+
+    time_chunk = num_days * 24
+    x_chunk = 175
+    y_chunk = 175
+
+    # Attributes that should be removed from all variables
+    # remove_attrs = ['FieldType', 'MemoryOrder', 'stagger', 'cell_methods']
+    #
+    # rename_dims = {'south_north': 'y', 'west_east': 'x',
+    #                'south_north_stag': 'y_stag', 'west_east_stag': 'x_stag',
+    #                'Time': 'time'}
+    #
+    # rename_vars = {'XLAT': 'lat', 'XLAT_U': 'lat_u', 'XLAT_V': 'lat_v',
+    #                'XLONG': 'lon', 'XLONG_U': 'lon_u', 'XLONG_V': 'lon_v'}
+
+    # Read the metadata file for modifications to variable attributes
+    # var_metadata = read_metadata(metadata_file)
+
+    # Add additional time attributes
+    # var_metadata['time'] = dict(axis='T', standard_name='time')
+
+    # Start up the cluster
+    client = Client(n_workers=8, threads_per_worker=1, memory_limit='24GB')
+
+    print(f'dask tmp directory: {dask.config.get("temporary-directory")}')
+
+    # Max total memory in gigabytes for cluster
+    total_mem = sum(vv['memory_limit'] for vv in client.scheduler_info()['workers'].values()) / 1024**3
+    total_threads = sum(vv['nthreads'] for vv in client.scheduler_info()['workers'].values())
+    print(f'Total memory: {total_mem:0.1f} GB')
+    print(f'Number of threads: {total_threads}')
+
+    # Maximum percentage of memory to use for rechunking per thread
+    max_percent = 0.7
+
+    max_mem = f'{total_mem / total_threads * max_percent:0.0f}GB'
+    print(f'Maximum memory per thread for rechunking: {max_mem}')
+    print('='*60)
+
+    # Read variables to process
+    # df = pd.read_csv(proc_vars_file)
+
+    fs = fsspec.filesystem('file')
+
+    start = time.time()
+
+    # cnk_idx = index_start
+    # c_start = st_date
+
+    ds = xr.open_dataset(zarr_store, engine='zarr',
+                         backend_kwargs=dict(consolidated=True), chunks={})
+
+    # st_date = base_date + datetime.timedelta(days=num_days * index_start)
+    # en_date = st_date + datetime.timedelta(days=num_days) - datetime.timedelta(hours=1)
+
+    # st_idx = index_start * time_cnk
+    # en_idx = (index_start + 1) * time_cnk
+
+    for ii in range(index_start, index_end):
+        t1 = time.time()
+
+        if base_date + datetime.timedelta(days=num_days * ii) >= en_date:
+            # No more dates left to process
+            break
+
+        c_start = ii * time_chunk
+        c_end = (ii + 1) * time_chunk
+
+        tstore_dir = f'{target_store}_{ii:05d}'
+
+        # rechunker requires empty tmp and target dirs
+        try:
+            fs.rm(temp_store, recursive=True)
+        except FileNotFoundError:
+            pass
+
+        try:
+            fs.rm(tstore_dir, recursive=True)
+        except FileNotFoundError:
+            pass
+
+        time.sleep(3)  # wait for files to be removed (necessary? hack!)
+
+        ds2 = ds[['T2', 'Q2', 'PSFC']].isel(time=slice(c_start, c_end))
+
+        ds2['RH2'] = rh_teten(ds2.Q2, ds2.PSFC, ds2.T2)
+        ds2['SH2'] = specific_humidity(ds2.Q2)
+        ds2['E2'] = vp(ds2.Q2, ds2.PSFC)
+        ds2['ESAT2'] = saturation_vp_teten(ds2.T2)
+        ds2['TD2'] = dewpoint_temperature_magnus(ds2.Q2, ds2.PSFC)
+
+        ds2.compute()
+        end = time.time()
+        print(f'Compute RH2, SH2, E2, ESAT2, TD2: {ii}, elapsed time: {end - t1:0.3f} s')
+
+        # t1 = time.time()
+        # ds2['TD2'] = compute_dewpoint_temperature(ds2.T2, ds2.E2, ds2.ESAT2)
+        # ds2.compute()
+        # end = time.time()
+        # print(f'Compute TD2: {ii}, elapsed time: {end - t1:0.3f} s')
+
+        var_list = ['time', 'RH2', 'SH2', 'E2', 'ESAT2', 'TD2']
+
+        t1 = time.time()
+        rechunker_wrapper(ds2[var_list], target_store=tstore_dir, temp_store=temp_store,
+                          mem=max_mem, consolidated=True, verbose=False,
+                          chunks={'time': time_chunk,
+                                  'y': y_chunk, 'x': x_chunk})
+        print(f'    rechunker: {time.time() - t1:0.3f} s')
+
+        end = time.time()
+        print(f'Chunk: {ii}, elapsed time: {(end - start) / 60.:0.3f}')
+
+    # while c_start < en_date:
+    #     # job_files = build_filelist(num_days, c_start, wrf_dir)
+    #     tstore_dir = f'{target_store}_{cnk_idx:05d}'
+    #     # num_time = len(job_files)
+    #
+    #     # slice('1979-10-01 00:00','1979-10-06 23:00')
+    #     ds2 = ds[['T2', 'Q2', 'PSFC']].sel(time=slice(c_start, ))
+    #     # =============================================
+    #     # Do some work here
+    #     # var_list = df['variable'].to_list()
+    #     # var_list.append('time')
+    #
+    #     # rechunker requires empty tmp and target dirs
+    #     try:
+    #         fs.rm(temp_store, recursive=True)
+    #     except:
+    #         pass
+    #     try:
+    #         fs.rm(tstore_dir, recursive=True)
+    #     except:
+    #         pass
+    #
+    #     time.sleep(3)  # wait for files to be removed (necessary? hack!)
+    #
+    #     t1 = time.time()
+    #     ds2['RH2'] = compute_rh(ds2.Q2, ds2.PSFC, ds2.T2)
+    #     ds2['SH2'] = compute_specific_humidity(ds2.Q2)
+    #     ds2['E2'] = compute_vp(ds2.Q2, ds2.PSFC)
+    #     ds2['ESAT2'] = compute_saturation_vp(ds2.T2)
+    #
+    #     ds2.compute()
+    #     end = time.time()
+    #     print(f'Compute RH2, SH2, E2, ESAT2: {cnk_idx}, elapsed time: {end - t1:0.3f} s')
+    #
+    #     t1 = time.time()
+    #     ds2['TD2'] = compute_dewpoint_temperature(ds2.T2, ds2.E2, ds2.ESAT2)
+    #     ds2.compute()
+    #     end = time.time()
+    #     print(f'Compute RH2, SH2, E2, ESAT2: {cnk_idx}, elapsed time: {end - t1:0.3f} s')
+    #
+    #     var_list = ['time', 'RH2', 'SH2', 'E2', 'ESAT2']
+    #
+    #     t1 = time.time()
+    #     rechunker_wrapper(ds2[var_list], target_store=tstore_dir, temp_store=temp_store,
+    #                       mem=max_mem, consolidated=True, verbose=False,
+    #                       chunks={'time': time_chunk,
+    #                               'y': y_chunk, 'x': x_chunk})
+    #     print(f'    rechunker: {time.time() - t1:0.3f} s')
+    #
+    #     end = time.time()
+    #     print(f'Chunk: {cnk_idx}, elapsed time: {(end - start) / 60.:0.3f}')
+    #
+    #     cnk_idx += 1
+    #     c_start += delta - datetime.timedelta(days=1)
+
+    client.close()
+
+    # Clear out the temporary storage
+    try:
+        fs.rm(temp_store, recursive=True)
+    except FileNotFoundError:
+        pass
+
+    if dask.config.get("temporary-directory") == '/dev/shm':
+        try:
+            fs.rm(f'/dev/shm/dask-worker-space', recursive=True)
+        except FileNotFoundError:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_rechunk_ja.py
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_rechunk_ja.py
@@ -1,0 +1,409 @@
+#!/usr/bin/env python
+
+# import numpy as np
+import os
+import argparse
+import dask
+import datetime
+import fsspec
+# import numpy as np
+import pandas as pd
+import rechunker
+import time
+import xarray as xr
+import zarr
+
+from dask.distributed import Client
+
+# CONUS404_W_d01_1980-09-30_23:00:00.nc  CONUS404_Z_d01_1980-09-30_23:00:00.nc
+
+def build_filelist(num_days, c_start, wrf_dir):
+    job_files = []
+
+    for dd in range(num_days):
+        cdate = c_start + datetime.timedelta(days=dd)
+
+        wy_dir = f'WY{cdate.year}'
+        if cdate >= datetime.datetime(cdate.year, 10, 1):
+            wy_dir = f'WY{cdate.year+1}'
+
+        for hh in range(24):
+            fdate = cdate + datetime.timedelta(hours=hh)
+
+            file_pat = f'{wrf_dir}/{wy_dir}/wrf2d_d01_{fdate.strftime("%Y-%m-%d_%H:%M:%S")}'
+            job_files.append(file_pat)
+    return job_files
+
+
+def read_metadata(filename):
+    # Read the metadata information file
+    fhdl = open(filename, 'r')   # , encoding='ascii')
+    rawdata = fhdl.read().splitlines()
+    fhdl.close()
+
+    it = iter(rawdata)
+    next(it)   # Skip header
+
+    var_metadata = {}
+    for row in it:
+        flds = row.split('\t')
+        var_metadata[flds[0]] = {}
+
+        if len(flds[1]) > 0:
+            var_metadata[flds[0]]['long_name'] = flds[1]
+
+        if len(flds[3]) > 0:
+            var_metadata[flds[0]]['integration_length'] = flds[3]
+        # if len(flds[8]) > 0:
+        #     var_metadata[flds[0]]['standard_name'] = flds[8]
+    return var_metadata
+
+
+def apply_metadata(ds, rename_dims, rename_vars, remove_attrs, var_metadata):
+    avail_dims = ds.dims.keys()
+    rename_dims_actual = {}
+
+    # Only change dimensions that exist in dataset
+    for kk, vv in rename_dims.items():
+        if kk in avail_dims:
+            rename_dims_actual[kk] = vv
+
+    ds = ds.rename(rename_dims_actual)
+    ds = ds.assign_coords({'time': ds.XTIME})
+
+    # Modify the attributes
+    for cvar in ds.variables:
+        # Remove unneeded attributes, update the coordinates attribute
+        for cattr in list(ds[cvar].attrs.keys()):
+            if cattr in remove_attrs:
+                del ds[cvar].attrs[cattr]
+
+            if cattr == 'coordinates':
+                # Change the coordinates attribute to new lat/lon naming
+                orig_coords = ds[cvar].attrs[cattr]
+                new_coords = []
+                for xx in orig_coords.split(' '):
+                    if xx not in rename_vars:
+                        continue
+                    new_coords.append(rename_vars[xx])
+                ds[cvar].attrs[cattr] = ' '.join(new_coords)
+
+        # Apply the new metadata
+        if cvar in var_metadata:
+            for kk, vv in var_metadata[cvar].items():
+                ds[cvar].attrs[kk] = vv
+
+    return ds
+
+
+def rechunker_wrapper(source_store, target_store, temp_store, chunks=None,
+                      mem=None, consolidated=False, verbose=True):
+    if isinstance(source_store, xr.Dataset):
+        g = source_store  # trying to work directly with a dataset
+        ds_chunk = g
+    else:
+        g = zarr.group(str(source_store))
+        # get the correct shape from loading the store as xr.dataset and parse the chunks
+        ds_chunk = xr.open_zarr(str(source_store))
+
+    group_chunks = {}
+    # newer tuple version that also takes into account when specified chunks are larger than the array
+    for var in ds_chunk.variables:
+        # Pick appropriate chunks from above, and default to full length chunks for
+        # dimensions that are not in `chunks` above.
+        group_chunks[var] = []
+        for di in ds_chunk[var].dims:
+            if di in chunks.keys():
+                if chunks[di] > len(ds_chunk[di]):
+                    group_chunks[var].append(len(ds_chunk[di]))
+                else:
+                    group_chunks[var].append(chunks[di])
+
+            else:
+                group_chunks[var].append(len(ds_chunk[di]))
+
+        group_chunks[var] = tuple(group_chunks[var])
+    if verbose:
+        print(f"Rechunking to: {group_chunks}")
+        print(f"mem:{mem}")
+    rechunked = rechunker.rechunk(g, target_chunks=group_chunks, max_mem=mem,
+                                  target_store=target_store, temp_store=temp_store)
+    rechunked.execute(retries=10)
+    if consolidated:
+        if verbose:
+            print('consolidating metadata')
+        zarr.convenience.consolidate_metadata(target_store)
+    if verbose:
+        print('done')
+
+
+def set_file_path(path1, path2=None):
+    '''Helper function to check/set the full path to a file.
+       path1 should include a filename
+       path2 should only be a directory'''
+
+    file_path = None
+
+    if os.path.isfile(path1):
+        # File exists, use the supplied path
+        file_path = os.path.realpath(path1)
+    else:
+        # file does not exist
+        if path2:
+            file_path = os.path.realpath(f'{path2}/{path1}')
+
+            if os.path.isfile(file_path):
+                # File exists in path2 so append it to the path
+                print(f'Using filepath, {file_path}')
+            else:
+                raise FileNotFoundError(f'File, {path1}, does not exist in {path2}')
+        else:
+            raise FileNotFoundError(f'File, {path1}, does not exist')
+
+    return file_path
+
+
+def set_target_path(path, base_dir=None, verbose=False):
+    new_path = None
+
+    if os.path.isdir(path):
+        # We're good, use it
+        new_path = os.path.realpath(path)
+        if verbose:
+            print(f'{new_path} exists.')
+    else:
+        # path is not a directory, does the parent directory exist?
+        pdir = os.path.dirname(path)
+
+        if pdir == '':
+            # There is no parent directory, try using base_dir if it exists
+            if base_dir:
+                # create/use
+                if not os.path.isdir(base_dir):
+                    raise FileNotFoundError(f'Base directory, {base_dir}, does not exist')
+
+                new_path = f'{base_dir}/{path}'
+
+                if os.path.isdir(new_path):
+                    if verbose:
+                        print(f'Using existing target path, {new_path}')
+                else:
+                    os.mkdir(new_path)
+
+                    if verbose:
+                        print(f'Creating target relative to base directory, {new_path}')
+            else:
+                # No base_dir supplied; create target path in current directory
+                new_path = os.path.realpath(path)
+                os.mkdir(new_path)
+
+                if verbose:
+                    print(f'Target path, {new_path}, created')
+        elif os.path.isdir(pdir):
+            # Parent path exists we just need to create the child directory
+            new_path = os.path.realpath(path)
+            os.mkdir(new_path)
+
+            if verbose:
+                print(f'Parent, {pdir}, exists. Created {new_path} directory')
+        else:
+            # print(f'ERROR: Parent of target path does not exist.')
+            raise FileNotFoundError(f'Parent, {pdir}, of target path, {path}, does not exist')
+
+    return new_path
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create cloud-optimized zarr files from WRF CONUS404 model output files')
+    parser.add_argument('-i', '--index', help='Index to process', required=True)
+    parser.add_argument('-b', '--base_dir', help='Directory to work in', required=False, default=None)
+    parser.add_argument('-w', '--wrf_dir', help='Base directory for WRF model output files', required=True)
+    parser.add_argument('-c', '--constants_file', help='Path to WRF constants', required=False, default=None)
+    parser.add_argument('-v', '--vars_file', help='File containing list of variables to include in output', required=True)
+    parser.add_argument('-d', '--dst_dir', help='Location to store rechunked zarr files', required=True)
+    parser.add_argument('-m', '--metadata_file', help='File containing metadata to include in zarr files', required=True)
+
+    args = parser.parse_args()
+
+    print(f'HOST: {os.environ.get("HOSTNAME")}')
+    if os.environ.get('HOSTNAME') == 'denali-login2':
+        exit(-1)
+
+    index_start = int(args.index)
+    print(f'{index_start=}')
+
+    base_dir = os.path.realpath(args.base_dir)
+    wrf_dir = os.path.realpath(args.wrf_dir)
+
+    const_file = set_file_path(args.constants_file, base_dir)
+    metadata_file = set_file_path(args.metadata_file, base_dir)
+    proc_vars_file = set_file_path(args.vars_file, base_dir)
+    target_store = f'{set_target_path(args.dst_dir, base_dir)}/target'
+
+    print(f'{base_dir=}')
+    print(f'{wrf_dir=}')
+    print(f'{const_file=}')
+    print(f'{metadata_file=}')
+    print(f'{proc_vars_file=}')
+    print(f'{target_store=}')
+    print('-'*60)
+
+    # base_dir = '/caldera/projects/usgs/water/wbeep/conus404_work/'
+    # wrf_dir = '/caldera/projects/usgs/water/impd/wrf-conus404/kyoko/wrfout_post'
+
+    # const_file = f'{base_dir}/wrf_constants_conus404_final.nc'
+    # metadata_file = f'{base_dir}/wrfout_metadata_w_std.csv'
+    # proc_vars_file = f'{base_dir}/wrf2d_vars_drb.csv'
+
+    # target_store = f'{base_dir}/test1/target'
+
+    temp_store = '/dev/shm/tmp'
+    base_date = datetime.datetime(1979, 10, 1)
+    num_days = 6
+    delta = datetime.timedelta(days=num_days)
+
+    # We specify a chunk index and the start date is selected based on that
+    index_start = int(args.index)
+    st_date = base_date + datetime.timedelta(days=num_days * index_start)
+    en_date = st_date + delta - datetime.timedelta(days=1)
+    print(f'{index_start=}')
+
+    print(f'{base_date=}')
+    print(f'{st_date=}')
+    print(f'{en_date=}')
+    print(f'{num_days=}')
+    print(f'{delta=}')
+
+    # if st_date.month != base_date.month or st_date.day != base_date.day:
+    if (st_date - base_date).days % num_days != 0:
+        print(f'Start date must begin at the start of a {num_days}-day chunk')
+
+    # index_start = int((st_date - base_date).days / num_days)
+    print(f'{index_start=}')
+    print('-'*60)
+
+    # time_chunk = 144
+    time_chunk = num_days * 24
+    x_chunk = 175
+    y_chunk = 175
+
+    # Attributes that should be removed from all variables
+    remove_attrs = ['FieldType', 'MemoryOrder', 'stagger', 'cell_methods']
+
+    rename_dims = {'south_north': 'y', 'west_east': 'x',
+                   'south_north_stag': 'y_stag', 'west_east_stag': 'x_stag',
+                   'Time': 'time'}
+
+    rename_vars = {'XLAT': 'lat', 'XLAT_U': 'lat_u', 'XLAT_V': 'lat_v',
+                   'XLONG': 'lon', 'XLONG_U': 'lon_u', 'XLONG_V': 'lon_v'}
+
+    # Read the metadata file for modifications to variable attributes
+    var_metadata = read_metadata(metadata_file)
+
+    # Add additional time attributes
+    var_metadata['time'] = dict(axis='T', standard_name='time')
+
+    # Start up the cluster
+    client = Client(n_workers=8, threads_per_worker=1, memory_limit='24GB')
+
+    print(f'dask tmp directory: {dask.config.get("temporary-directory")}')
+
+    # Max total memory in gigabytes for cluster
+    total_mem = sum(vv['memory_limit'] for vv in client.scheduler_info()['workers'].values()) / 1024**3
+    total_threads = sum(vv['nthreads'] for vv in client.scheduler_info()['workers'].values())
+    print(f'Total memory: {total_mem:0.1f} GB')
+    print(f'Number of threads: {total_threads}')
+
+    # Maximum percentage of memory to use for rechunking per thread
+    max_percent = 0.7
+
+    max_mem = f'{total_mem / total_threads * max_percent:0.0f}GB'
+    print(f'Maximum memory per thread for rechunking: {max_mem}')
+    print('='*60)
+
+    # Read variables to process
+    df = pd.read_csv(proc_vars_file)
+
+    fs = fsspec.filesystem('file')
+
+    start = time.time()
+
+    cnk_idx = index_start
+    c_start = st_date
+
+    while c_start < en_date:
+        job_files = build_filelist(num_days, c_start, wrf_dir)
+        tstore_dir = f'{target_store}_{cnk_idx:05d}'
+        # num_time = len(job_files)
+
+        # =============================================
+        # Do some work here
+        var_list = df['variable'].to_list()
+        var_list.append('time')
+
+        # rechunker requires empty tmp and target dirs
+        try:
+            fs.rm(temp_store, recursive=True)
+        except FileNotFoundError:
+            pass
+        try:
+            fs.rm(tstore_dir, recursive=True)
+        except FileNotFoundError:
+            pass
+
+        time.sleep(3)  # wait for files to be removed (necessary? hack!)
+
+        # ~~~~~~~~~~~~~~~~~~~~~~~~~
+        # Open netcdf source files
+        t1 = time.time()
+        ds2d = xr.open_mfdataset(job_files, concat_dim='Time', combine='nested',
+                                 parallel=True, coords="minimal", data_vars="minimal",
+                                 compat='override', chunks={})
+
+        if cnk_idx == 0:
+            # Add the wrf constants during the first time chunk
+            df_const = xr.open_dataset(const_file, chunks={})
+            ds2d = ds2d.merge(df_const)
+            ds2d = ds2d.rename(rename_vars)
+
+            for vv in df_const.variables:
+                if vv in rename_vars:
+                    var_list.append(rename_vars[vv])
+                else:
+                    var_list.append(vv)
+            df_const.close()
+
+        ds2d = apply_metadata(ds2d, rename_dims, rename_vars, remove_attrs, var_metadata)
+        print(f'    Open mfdataset: {time.time() - t1:0.3f} s')
+
+        t1 = time.time()
+        rechunker_wrapper(ds2d[var_list], target_store=tstore_dir, temp_store=temp_store,
+                          mem=max_mem, consolidated=True, verbose=False,
+                          chunks={'time': time_chunk,
+                                  'y': y_chunk, 'x': x_chunk,
+                                  'y_stag': y_chunk, 'x_stag': x_chunk})
+        print(f'    rechunker: {time.time() - t1:0.3f} s')
+
+        end = time.time()
+        print(f'Chunk: {cnk_idx}, elapsed time: {(end - start) / 60.:0.3f}, {job_files[0]}')
+
+        cnk_idx += 1
+        c_start += delta
+
+    client.close()
+    
+    # Clear out the temporary storage
+    try:
+        fs.rm(temp_store, recursive=True)
+    except:
+        pass
+
+    if dask.config.get("temporary-directory") == '/dev/shm':
+        try:
+            fs.rm(f'/dev/shm/dask-worker-space', recursive=True)
+        except:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_to_zarr.py
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/conus404_to_zarr.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+import argparse
+import dask
+import fsspec
+import pandas as pd
+import os
+import time
+import xarray as xr
+
+from dask.distributed import Client
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Create cloud-optimized zarr files from WRF CONUS404')
+    parser.add_argument('-i', '--index', help='Index to process', type=int, required=True)
+    parser.add_argument('-s', '--step', help='Number of indices to process from start index', type=int, required=True)
+    parser.add_argument('-b', '--base_dir', help='Directory to work in', required=False, default=None)
+    parser.add_argument('-d', '--dst_dir', help='Location to store file zarr file', required=True)
+    parser.add_argument('-z', '--zarr_dir', help='Location of source zarr files', required=True)
+
+    args = parser.parse_args()
+
+    first_idx = args.index
+    idx_span = args.step
+    last_idx = first_idx + idx_span
+
+    base_dir = os.path.realpath(args.base_dir)
+    outzarr_dir = os.path.realpath(args.dst_dir)
+
+    src_zarr = os.path.realpath(f'{args.zarr_dir}/target_*')
+
+    zarr_whole = f'{outzarr_dir}/conus404_whole.zarr'
+
+    # base_dir = '/caldera/projects/usgs/water/wbeep/conus404_work'
+    # outzarr_dir = f'{base_dir}/zarr_out'
+
+    print(f'{first_idx=}')
+    print(f'{idx_span=}')
+    print(f'{last_idx=}')
+    print('-'*60)
+    print(f'{base_dir=}')
+    print(f'{outzarr_dir=}')
+    print(f'{src_zarr=}')
+    print(f'{zarr_whole=}')
+
+    time_cnk = 144
+
+    fs = fsspec.filesystem('file')
+    # zlist = sorted(fs.glob(f'{base_dir}/test1/target_0*'))
+    zlist = sorted(fs.glob(src_zarr))
+    num_targets = len(zlist)
+
+    if num_targets < last_idx - 1:
+        idx_span = num_targets - first_idx
+        last_idx = first_idx + idx_span
+        print(f'NOTE: Adjusted processing indices')
+
+    print(f'Index start: {first_idx}; Index end: {last_idx - 1}')
+
+    # Start up the cluster
+    # client = Client(n_workers=8, threads_per_worker=1, memory_limit='24GB')
+    client = Client()
+
+    print(f'dask tmp directory: {dask.config.get("temporary-directory")}')
+
+    # Max total memory in gigabytes for cluster
+    total_mem = sum(vv['memory_limit'] for vv in client.scheduler_info()['workers'].values()) / 1024**3
+    total_threads = sum(vv['nthreads'] for vv in client.scheduler_info()['workers'].values())
+    print(f'Total memory: {total_mem:0.1f} GB')
+    print(f'Number of threads: {total_threads}')
+
+    t1_proc = time.time()
+    if first_idx == 0:
+        # Open first and last zarr file to get date range
+        ds0 = xr.open_dataset(zlist[0], engine='zarr', chunks={})
+        ds1 = xr.open_dataset(zlist[-1], engine='zarr', chunks={})
+
+        # TODO: the freq argument must reflect the time interval (e.g hourly, daily)
+        dates = pd.date_range(start=ds0.time[0].values, end=ds1.time[-1].values, freq='1h')
+
+        # Have to drop the constant variables (e.g. variables having no time dimension)
+        drop_vars = ['BF', 'BH', 'C1F', 'C1H', 'C2F', 'C2H', 'C3F', 'C3H', 'C4F', 'C4H',
+                     'CF1', 'CF2', 'CF3', 'CFN', 'CFN1', 'CLAT', 'COSALPHA', 'DN', 'DNW',
+                     'DZS', 'E', 'F', 'FNM', 'FNP', 'HGT', 'ISLTYP', 'IVGTYP', 'LAKEMASK',
+                     'LANDMASK', 'LU_INDEX', 'MAPFAC_M', 'MAPFAC_MX', 'MAPFAC_MY',
+                     'MAPFAC_U', 'MAPFAC_UX', 'MAPFAC_UY', 'MAPFAC_V', 'MAPFAC_VX', 'MAPFAC_VY',
+                     'MAX_MSTFX', 'MAX_MSTFY', 'MF_VX_INV', 'MUB', 'P00', 'PB', 'PHB',
+                     'P_STRAT', 'P_TOP', 'RDN', 'RDNW', 'RDX', 'RDY', 'SHDMAX', 'SHDMIN',
+                     'SINALPHA', 'SNOALB', 'T00', 'TISO', 'TLP', 'TLP_STRAT', 'VAR',
+                     'VAR_SSO', 'XLAND', 'lat', 'lat_u', 'lat_v', 'lon', 'lon_u', 'lon_v',
+                     'ZETATOP', 'ZNU', 'ZNW', 'ZS']
+
+        source_dataset = ds0.drop_vars(drop_vars, errors='ignore')
+
+        template = (source_dataset.chunk().pipe(xr.zeros_like).isel(time=0, drop=True).expand_dims(time=len(dates)))
+        template['time'] = dates
+        template = template.chunk({'time': time_cnk})
+
+        # Writes no data (yet)
+        template.to_zarr(zarr_whole, compute=False, consolidated=True, mode='w')
+
+        # Writes the data
+        ds0.drop_vars(drop_vars).to_zarr(zarr_whole, region={'time': slice(0, time_cnk)})
+
+        # Add the wrf constants
+        ds0[drop_vars].to_zarr(zarr_whole, mode='a')
+        print(f'  Index {first_idx} (pre-create output): {time.time() - t1_proc:0.3f} s')
+
+    for i in range(first_idx, last_idx):
+        if i == 0:
+            continue
+        t1 = time.time()
+        start = i * time_cnk
+        stop = (i + 1) * time_cnk
+
+        # print(zlist[i])
+        dsi = xr.open_dataset(zlist[i], engine='zarr', chunks={})
+        dsi.to_zarr(zarr_whole, region={'time': slice(start, stop)})
+        print(f'  Index {i}: {time.time() - t1:0.3f} s')
+
+    client.close()
+    if dask.config.get("temporary-directory") == '/dev/shm':
+        try:
+            fs.rm(f'/dev/shm/dask-worker-space', recursive=True)
+        except FileNotFoundError:
+            pass
+
+    print(f'Total time: {time.time() - t1_proc:0.3f} s')
+
+
+if __name__ == '__main__':
+    main()

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/readme.md
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/readme.md
@@ -1,0 +1,58 @@
+Scripts used to rechunk and convert CONUS404 module output to cloud-optimized zarr format
+
+The rechunking and zarr merging scripts can be executed individually 
+(e.g. while in an interactive HPC job) or submitted as a batch SLURM job.
+
+## Batch SLURM job
+
+The batch job is designed to run on denali. Currently paths are hardcoded in the
+conus404_rechunk_ja.py and conus404_to_zarr.py scripts. Running the following,
+
+```bash
+./submit_conus404_processing.sh
+```
+
+will submit jobs for rechunking the CONUS404 variables and merging the chunks 
+into a single zarr dataset. Each job is a job array and subsequents jobs won't 
+run until the prior job completes successfully (e.g. rechunking must complete 
+successfully before the zarr merging job will run). Job output is saved into 
+the current working directory.
+
+Please note: for the batch jobs to work a conda environment named `pangeo` must
+exist (with all required libraries) and the scripts must be in the current 
+working directory from where the shell script it run.
+
+## Manual execution in an interactive job
+To manually run the rechunker
+```bash
+python conus404_rechunk_ja.py -i <index>
+```
+where `<index>` is the zero-based chunk number to process. The rechunker processes 
+6-day chunks of data with chunk indices starting at zero for the first 6-day chunk
+indexed from the first model time (1979-10-01 00:00:00).
+
+Each processed chunk is written to individual directories.
+
+Once all chunks have been processed they need to be merged into a single zarr 
+dataset. The script `conus404_to_zarr.py` is used to do this. The first index (zero) 
+has special meaning; when this index is processed the initial empty zarr dataset is 
+created, WRF constant variables are added, and a time variable for the entire
+period is created. Subsequent indices only copy in the data for the non-constant 
+variables.
+
+To do this manually you would type something like the folllowing:
+
+```bash
+python conus404_to_zarr.py -i <index> -s <step>
+```
+
+where `<index>` is the zero-based chunk to add to the final zarr dataset and 
+`<step>` is the number of chunks to process. For example,
+
+```bash
+python conus404_to_zarr.py -i 0 -s 10
+```
+would process chunks 0 to 9. Chunk zero would trigger the initial zarr dataset
+creation and add the data from chunk 0. Then chunks 1-9 would be added to the zarr 
+dataset. 
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/rechunk.sbatch
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/rechunk.sbatch
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J rechunk
+#SBATCH -t 00:20:00
+#SBATCH -o %j-rechunk.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=10
+# #SBATCH --array=0-2495%50
+
+export PATH="$PATH:$HOME/miniconda3/bin"
+
+source activate pangeo
+
+base_dir=/caldera/projects/usgs/water/wbeep/conus404_work
+wrf_dir=wrfout_post
+const_file=wrf_constants_conus404_final.nc
+metadata_file=wrfout_metadata_w_std.csv
+proc_vars_file=2022-03-16_DRB_addl_vars.csv
+target_store=rechunk_tmp
+
+python /caldera/projects/usgs/water/wbeep/conus404_work/conus404_rechunk_ja.py -i $SLURM_ARRAY_TASK_ID -b $base_dir -w $wrf_dir -c $const_file -v $proc_vars_file -m $metadata_file -d $target_store
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/rechunk_derived.sbatch
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/rechunk_derived.sbatch
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J rechunk
+#SBATCH -t 00:20:00
+#SBATCH -o %j-rechunk.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=10
+# #SBATCH --array=0-2495%50
+
+export PATH="$PATH:$HOME/miniconda3/bin"
+
+source activate pangeo
+
+base_dir=/caldera/projects/usgs/water/wbeep/conus404_work
+wrf_dir=wrfout_post
+const_file=wrf_constants_conus404_final.nc
+metadata_file=wrfout_metadata_w_std.csv
+proc_vars_file=2022-03-16_DRB_addl_vars.csv
+target_store=rechunk_tmp
+
+python /caldera/projects/usgs/water/wbeep/conus404_work/conus404_rechunk_ja.py -i $SLURM_ARRAY_TASK_ID -b $base_dir -w $wrf_dir -c $const_file -v $proc_vars_file -m $metadata_file -d $target_store
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/submit_conus404_processing.sh
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/submit_conus404_processing.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+STEP=10
+MAX_JOBS=30
+
+LAST_STEP=2495
+
+#sbatch --array=0-10:10 to_zarr.sbatch
+#sbatch --dependency=afterok:2749205 --array=0-100:10 to_zarr.sbatch
+
+# First rechunk CONUS404 model output
+jobid0=$(sbatch --parsable --array=0-${LAST_STEP}%${MAX_JOBS} rechunk.sbatch)
+
+# Create final ZARR of CONUS404 data
+jobid1=$(sbatch --parsable --dependency=afterok:${jobid0} --array=0-9:${STEP} to_zarr.sbatch)
+sbatch --dependency=afterok:${jobid1} --array=10-${LAST_STEP}:${STEP}%${MAX_JOBS} to_zarr.sbatch

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/to_zarr.sbatch
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/hourly/to_zarr.sbatch
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH -J cat_zarr
+#SBATCH -t 00:20:00
+#SBATCH -o %j-to_zarr.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=40
+#  #SBATCH --array=10-100:10
+
+# STEP should match the stride in the --array argument
+export STEP=10
+export PATH="$PATH:$HOME/miniconda3/bin"
+
+source activate pangeo
+
+base_dir=/caldera/projects/usgs/water/wbeep/conus404_work
+dst_zarr_dir=/caldera/projects/usgs/water/wbeep/conus404_work/zarr_Z
+src_zarr_dir=/caldera/projects/usgs/water/wbeep/conus404_work/rechunk_tmp
+
+echo $SLURM_ARRAY_TASK_ID
+python /caldera/projects/usgs/water/wbeep/conus404_work/conus404_to_zarr.py -i $SLURM_ARRAY_TASK_ID -s $STEP -b $base_dir -z $src_zarr_dir -d $dst_zarr_dir
+

--- a/dataset_preprocessing/archive/conus404_subset_to_zarr/readme.md
+++ b/dataset_preprocessing/archive/conus404_subset_to_zarr/readme.md
@@ -1,0 +1,6 @@
+Scripts used to rechunk and convert CONUS404 module output to cloud-optimized zarr format
+
+The rechunking and zarr merging scripts can be executed individually 
+(e.g. while in an interactive HPC job) or submitted as a batch SLURM job.
+
+

--- a/dataset_preprocessing/demos/era5-land-bitinfo.ipynb
+++ b/dataset_preprocessing/demos/era5-land-bitinfo.ipynb
@@ -1,0 +1,215 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5cf6238f-6ee2-4359-abda-8599a0a1c734",
+   "metadata": {},
+   "source": [
+    "# Bitinfo for ERA5-Land data\n",
+    "Here we test each dimension for bitinfo. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31a0b36f-bbdb-4f21-869a-254626621047",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import xbitinfo as xb\n",
+    "import hvplot.xarray\n",
+    "import fsspec "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "fcc2acb1-fa8e-4555-92f1-ae828a2db237",
+   "metadata": {},
+   "source": [
+    "Copy netcdf file obtained using the cdsapi service from cloud to local disk:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ad5d538d-6910-4b25-8dc6-4f1ce1439302",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3file = 's3://rsignellbucket1/testing/conus_2019-12-01.nc'\n",
+    "local_file = 'conus_2019-12-01.nc'\n",
+    "local_compressed_file = local_file.replace('.nc','_br.nc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9ba0566e-6dcb-4a26-a63a-04156fd3cbf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = fsspec.filesystem('s3', anon=True, \n",
+    "                       client_kwargs={'endpoint_url': 'https://mghp.osn.xsede.org'})\n",
+    "fs.download(s3file, local_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f62ee436-64dd-461c-9cac-62610469896d",
+   "metadata": {},
+   "source": [
+    "Explore local file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f83dc7d4-f902-4a62-9d6d-7ced08b58243",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(local_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8bbd8b7d-7e68-4fa2-b9eb-56f54e5f6582",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "43e5c395-4154-4514-a235-ad1d1dfed5d1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ds.hvplot(x='longitude', y='latitude', geo=True, rasterize=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "12b32ad9-7a82-430a-b9aa-ecc8b4a5ba45",
+   "metadata": {},
+   "source": [
+    "Subset a region to get all land (bitinfo gives misleading answers if masked areas are included)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49a27e10-7dda-4ca6-bb11-885a87e5653c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_subset = ds.sel(longitude=slice(-120,-93),latitude=slice(50,38))\n",
+    "ds_subset.hvplot(x='longitude', y='latitude', geo=True, rasterize=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c71abf6e-b637-412d-a698-4ec6965558be",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bitinfo = xb.get_bitinformation(ds_subset, dim=\"latitude\")  \n",
+    "keepbits = xb.get_keepbits(bitinfo, inflevel=0.99)  # get number of mantissa bits to keep for 99% real information\n",
+    "keepbits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13695877-e359-4e2f-8d34-ae3267720eeb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bitinfo = xb.get_bitinformation(ds_subset, dim=\"longitude\")  \n",
+    "keepbits = xb.get_keepbits(bitinfo, inflevel=0.99)  # get number of mantissa bits to keep for 99% real information\n",
+    "keepbits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "074b97e0-e3a8-43c4-aca6-40fc1ee2b652",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bitinfo = xb.get_bitinformation(ds_subset, dim=\"time\")  # calling bitinformation.jl.bitinformation\n",
+    "keepbits = xb.get_keepbits(bitinfo, inflevel=0.99)  # get number of mantissa bits to keep for 99% real information\n",
+    "keepbits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7324b40-4482-4184-988a-8a685bbc461c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds_bitrounded = xb.xr_bitround(ds, keepbits)  # bitrounding keeping only keepbits mantissa bits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "560dc331-b9b9-4d5b-b4f2-7772d9c85216",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "ds_bitrounded.to_compressed_netcdf(local_compressed_file)  # save to netcdf with compression"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "06438cc2-c97d-4628-90e4-e15be2decfde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "! du -h *.nc"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14f063cc-e37d-4146-bdb1-f80c5c47adac",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keepbits.to_netcdf('keepbits.nc')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:bitinfo]",
+   "language": "python",
+   "name": "conda-env-bitinfo-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dataset_preprocessing/demos/era5-land_api_dask.ipynb
+++ b/dataset_preprocessing/demos/era5-land_api_dask.ipynb
@@ -1,0 +1,511 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "93744300-0bc8-453e-b801-a4b1ced3b802",
+   "metadata": {},
+   "source": [
+    "# Obtain NetCDF file from ERA5-Land using the CDSAPI\n",
+    "Information here: https://confluence.ecmwf.int/display/CKB/ERA5-Land%3A+data+documentation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9a5cc283-be10-4cf0-ba8d-d5f3148ddbde",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import hvplot.xarray\n",
+    "import pandas as pd\n",
+    "import dask\n",
+    "import fsspec\n",
+    "import cdsapi"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8e1b8fdb-c697-4162-9442-e2b4f4cc5c4a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "c = cdsapi.Client()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a38d0e7-c017-4c2c-bfb4-88a999781a9c",
+   "metadata": {},
+   "source": [
+    "#### Spin up Dask Cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6ee23cd8-6f94-4551-9e2a-e0487a13b16c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_cluster(resource):\n",
+    "    ''' Helper function to configure cluster\n",
+    "    '''\n",
+    "    if resource == 'denali':\n",
+    "        cluster = LocalCluster(threads_per_worker=1)\n",
+    "        client = Client(cluster)\n",
+    "    \n",
+    "    elif resource == 'tallgrass':\n",
+    "        from dask_jobqueue import SLURMCluster\n",
+    "        cluster = SLURMCluster(queue='cpu', cores=1, interface='ib0',\n",
+    "                               job_extra=['--nodes=1', '--ntasks-per-node=1', '--cpus-per-task=1'],\n",
+    "                               memory='6GB')\n",
+    "        cluster.adapt(maximum_jobs=30)\n",
+    "        client = Client(cluster)\n",
+    "        \n",
+    "    elif resource == 'local':\n",
+    "        import os\n",
+    "        import warnings\n",
+    "        warnings.warn(\"Running locally can result in costly data transfers!\\n\")\n",
+    "        n_cores = os.cpu_count() # set to match your machine\n",
+    "        cluster = LocalCluster(threads_per_worker=n_cores)\n",
+    "        client = Client(cluster)\n",
+    "        \n",
+    "    elif resource in ['esip-qhub-gateway-v0.4']:   \n",
+    "        import sys, os\n",
+    "        sys.path.append(os.path.join(os.environ['HOME'],'shared','users','lib'))\n",
+    "        import ebdpy as ebd\n",
+    "        aws_profile = 'esip-qhub'\n",
+    "        ebd.set_credentials(profile=aws_profile)  # sets credentials for notebook\n",
+    "        aws_region = 'us-west-2'\n",
+    "        endpoint = f's3.{aws_region}.amazonaws.com'\n",
+    "        ebd.set_credentials(profile=aws_profile, region=aws_region, endpoint=endpoint)\n",
+    "        worker_max = 3\n",
+    "        client,cluster = ebd.start_dask_cluster(profile=aws_profile, worker_max=worker_max, \n",
+    "                                              region=aws_region, use_existing_cluster=True,\n",
+    "                                              adaptive_scaling=False, wait_for_cluster=False, \n",
+    "                                              worker_profile='Small Worker', propagate_env=True)\n",
+    "        \n",
+    "    return client, cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "480cec43-bb52-4c7b-ab49-b1ce84cd5d99",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resource = 'esip-qhub-gateway-v0.4' #denali, tallgrass, local, esip-qhub-gateway-v0.4"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3bb3ba9-11c6-44a3-b87f-813fbd42932c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "client, cluster = configure_cluster(resource)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08b688c8-9f77-4bc7-8f8e-11061173fa43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.scale(30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38fc5607-a07e-4475-b364-303f3839d3d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# client.wait_for_workers(n_workers=30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "dff5180f-c026-4223-83f4-69698f7d4e15",
+   "metadata": {},
+   "source": [
+    "#### Specify variables, spatial and temporal extents"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d9c375ea-97c2-4fd9-bfcb-7993ed84249e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "var_list = ['snow_depth_water_equivalent', 'soil_temperature_level_1']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68a014cc-566f-428a-8838-f8c74bd08e47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# CONUS\n",
+    "north = 49.3457868 \n",
+    "west = -124.7844079 \n",
+    "east = -66.9513812 \n",
+    "south =  24.7433195 "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c435078c-9666-4b12-94de-63049ea66de2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs = fsspec.filesystem('s3', anon=False,  skip_instance_cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8912fc6-8673-415c-9b70-05c640e79906",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dates = pd.date_range('1980-12-01','2022-01-31', freq='14D')\n",
+    "print(dates)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42ee94a5-51cb-4c12-9148-2cbae46b2fd4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_dates = [date.strftime('%Y-%m-%d') for date in dates[:-1]]\n",
+    "stop_dates = [(date+pd.offsets.Day(13)).strftime('%Y-%m-%d') for date in dates[:-1]]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "08e24413-c808-4c8f-86f5-4fadcdd744b8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_files = [f'esip-qhub/usgs/era5_land/conus_{start_date}.nc' for start_date in start_dates]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "959e8c92-d28a-4f26-9aef-d92e434c4213",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_files_processed = fs.glob('esip-qhub/usgs/era5_land/conus_*.nc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4cef589c-d3c2-4daf-ae5f-a0b259e6b420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_files_to_create = list(set(s3_files) - set(s3_files_processed))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73cc0262-b71c-47e9-a5f7-e45019f78d2e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(s3_files))\n",
+    "print(len(s3_files_to_create))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b6b27b20-bde0-4efc-aa5b-4c8eb59a1474",
+   "metadata": {},
+   "source": [
+    "#### test generation of start_date and stop_date from s3file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "932e98db-c8c7-4739-9f7e-51dba0d2f7bf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import datetime as dt\n",
+    "s3file = s3_files_to_create[0]\n",
+    "start_date = s3file.split('_')[-1].split('.')[0]\n",
+    "s = start_date.split('-')\n",
+    "stop_date = (dt.datetime(int(s[0]),int(s[1]),int(s[2])) + pd.offsets.Day(13)).strftime('%Y-%m-%d')\n",
+    "print(start_date)\n",
+    "print(stop_date)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b0821072-0f7f-4337-a941-6cd44e9da83b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_chunk(s3file, keepbits):\n",
+    "    \n",
+    "    from numcodecs.bitround import BitRound\n",
+    "    import pandas as pd\n",
+    "\n",
+    "    def _np_bitround(data, keepbits):\n",
+    "        \"\"\"Bitround for Arrays.\"\"\"\n",
+    "        codec = BitRound(keepbits=keepbits)\n",
+    "        data = data.copy()  # otherwise overwrites the input\n",
+    "        encoded = codec.encode(data)\n",
+    "        return codec.decode(encoded)\n",
+    "\n",
+    "\n",
+    "    def _keepbits_interface(da, keepbits):\n",
+    "        \"\"\"Common interface to allowed keepbits types\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        da : :py:class:`xarray.DataArray`\n",
+    "          Input data to bitround\n",
+    "        keepbits : int, dict of {str: int}, :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`\n",
+    "          How many bits to keep as int\n",
+    "        Returns\n",
+    "        -------\n",
+    "        keep : int\n",
+    "          Number of keepbits for variable given in ``da``\n",
+    "        \"\"\"\n",
+    "        assert isinstance(da, xr.DataArray)\n",
+    "        if isinstance(keepbits, int):\n",
+    "            keep = keepbits\n",
+    "        elif isinstance(keepbits, dict):\n",
+    "            v = da.name\n",
+    "            if v in keepbits.keys():\n",
+    "                keep = keepbits[v]\n",
+    "            else:\n",
+    "                raise ValueError(f\"name {v} not for in keepbits: {keepbits.keys()}\")\n",
+    "        elif isinstance(keepbits, xr.Dataset):\n",
+    "            assert keepbits.coords[\"inflevel\"].shape <= (\n",
+    "                1,\n",
+    "            ), \"Information content is only allowed for one 'inflevel' here. Please make a selection.\"\n",
+    "            if \"dim\" in keepbits.coords:\n",
+    "                assert keepbits.coords[\"dim\"].shape <= (\n",
+    "                    1,\n",
+    "                ), \"Information content is only allowed along one dimension here. Please select one `dim`. To find the maximum keepbits, simply use `keepbits.max(dim='dim')`\"\n",
+    "            v = da.name\n",
+    "            if v in keepbits.keys():\n",
+    "                keep = int(keepbits[v])\n",
+    "            else:\n",
+    "                raise ValueError(f\"name {v} not for in keepbits: {keepbits.keys()}\")\n",
+    "        elif isinstance(keepbits, xr.DataArray):\n",
+    "            assert keepbits.coords[\"inflevel\"].shape <= (\n",
+    "                1,\n",
+    "            ), \"Information content is only allowed for one 'inflevel' here. Please make a selection.\"\n",
+    "            assert keepbits.coords[\"dim\"].shape <= (\n",
+    "                1,\n",
+    "            ), \"Information content is only allowed along one dimension here. Please select one `dim`. To find the maximum keepbits, simply use `keepbits.max(dim='dim')`\"\n",
+    "            v = da.name\n",
+    "            if v == keepbits.name:\n",
+    "                keep = int(keepbits)\n",
+    "            else:\n",
+    "                raise KeyError(f\"no keepbits found for variable {v}\")\n",
+    "        else:\n",
+    "            raise TypeError(f\"type {type(keepbits)} is not a valid type for keepbits.\")\n",
+    "        return keep\n",
+    "    \n",
+    "    def xr_bitround(da, keepbits):\n",
+    "    \n",
+    "        \"\"\"Apply bitrounding based on keepbits from :py:func:`xbitinfo.xbitinfo.get_keepbits` for :py:class:`xarray.Dataset` or :py:class:`xarray.DataArray` wrapping ``numcodecs.bitround``\n",
+    "        Parameters\n",
+    "        ----------\n",
+    "        da : :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`\n",
+    "          Input data to bitround\n",
+    "        keepbits : int, dict of {str: int}, :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`\n",
+    "          How many bits to keep as int. Fails if dict or :py:class:`xarray.Dataset` and key or variable not present.\n",
+    "        Returns\n",
+    "        -------\n",
+    "        da_bitrounded : :py:class:`xarray.DataArray` or :py:class:`xarray.Dataset`\n",
+    "        Example\n",
+    "        -------\n",
+    "        >>> ds = xr.tutorial.load_dataset(\"air_temperature\")\n",
+    "        >>> info_per_bit = xb.get_bitinformation(ds, dim=\"lon\")\n",
+    "        >>> keepbits = xb.get_keepbits(info_per_bit, 0.99)\n",
+    "        >>> ds_bitrounded = xb.xr_bitround(ds, keepbits)\n",
+    "        \"\"\"\n",
+    "        if isinstance(da, xr.Dataset):\n",
+    "            da_bitrounded = da.copy()\n",
+    "            for v in da.data_vars:\n",
+    "                da_bitrounded[v] = xr_bitround(da[v], keepbits)\n",
+    "            return da_bitrounded\n",
+    "\n",
+    "        assert isinstance(da, xr.DataArray)\n",
+    "        keep = _keepbits_interface(da, keepbits)\n",
+    "\n",
+    "        da = xr.apply_ufunc(_np_bitround, da, keep, dask=\"parallelized\", keep_attrs=True)\n",
+    "        da.attrs[\"_QuantizeBitRoundNumberOfSignificantDigits\"] = keep\n",
+    "        return da\n",
+    "\n",
+    "    import datetime as dt   \n",
+    "    start_date = s3file.split('_')[-1].split('.')[0]\n",
+    "    s = start_date.split('-')\n",
+    "    stop_date = (dt.datetime(int(s[0]),int(s[1]),int(s[2])) + pd.offsets.Day(13)).strftime('%Y-%m-%d')\n",
+    "    local_ncfile = f'era5land_{start_date}.nc'\n",
+    "    local_nc4file = f'era5_land_{start_date}.nc'\n",
+    "    c.retrieve(\n",
+    "        'reanalysis-era5-land',\n",
+    "        {\n",
+    "            'variable': var_list, \n",
+    "            'area'    : f'{north}/{west}/{south}/{east}', \n",
+    "            'date'    : f'{start_date}/{stop_date}',\n",
+    "            'time': ['00:00', '01:00', '02:00', '03:00', '04:00', '05:00',\n",
+    "                     '06:00', '07:00', '08:00', '09:00', '10:00', '11:00',\n",
+    "                     '12:00', '13:00', '14:00', '15:00', '16:00', '17:00',\n",
+    "                     '18:00', '19:00', '20:00', '21:00', '22:00', '23:00'],\n",
+    "            'format':'netcdf'\n",
+    "        },\n",
+    "        local_ncfile)\n",
+    "        \n",
+    "    ds = xr.open_dataset(local_ncfile)\n",
+    "    ds_bitrounded = xr_bitround(ds, keepbits)\n",
+    "    encoding = {}\n",
+    "    for data_var in ds.data_vars:\n",
+    "        encoding[data_var]=dict(dtype='float32', zlib=True)\n",
+    "\n",
+    "    encoding['latitude'] = {'_FillValue':None}\n",
+    "    encoding['longitude'] = {'_FillValue':None}\n",
+    "\n",
+    "    ds_bitrounded.to_netcdf(local_nc4file, engine='netcdf4', encoding=encoding, mode='w')  \n",
+    "    fs.upload(local_nc4file, s3file)\n",
+    "    fs2 = fsspec.filesystem('file')\n",
+    "    fs2.rm([local_ncfile, local_nc4file])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0201d76-2a91-4889-9d96-23172b695899",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keepbits = xr.open_dataset('keepbits.nc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26211d13-362e-4378-bbbe-2f7a5cd9d726",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "keepbits"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7ef3f61f-2b35-4f66-ba7b-d0d01da440f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "_ = dask.compute(*[dask.delayed(get_chunk)(s3file,keepbits) for s3file in s3_files_to_create], retries=10);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9816c535-b3db-4bbb-860d-f52a6b66c436",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flist = fs.glob('esip-qhub/usgs/era5_land/*.nc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "87aec089-15f4-4081-81f8-ce1be79d8375",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs.info(flist[-1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f93f2365-68a9-47d4-a863-088d30a3c921",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(fs.open(flist[-1]), chunks={})"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "069cad72-008a-4e42-8da6-a134a8ede437",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d62484f6-6b46-4f45-ab92-e364e421ff85",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.sd.isel(time=0).plot()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a770d74d-6bf4-4694-98df-206a9012d927",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "users-pangeo",
+   "language": "python",
+   "name": "conda-env-users-pangeo-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dataset_preprocessing/demos/era5-land_kerchunk.ipynb
+++ b/dataset_preprocessing/demos/era5-land_kerchunk.ipynb
@@ -1,0 +1,593 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "5b86af71-052b-4081-844b-779db459068d",
+   "metadata": {},
+   "source": [
+    "# Create/update a Zarr Virtual Dataset from a collection of ERA5-Land NetCDF3 files on S3"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b6ba617-9772-4ecf-aa7a-2be2a4bcfa1d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import fsspec\n",
+    "import ujson   # fast json\n",
+    "from kerchunk.hdf import SingleHdf5ToZarr \n",
+    "from kerchunk.combine import MultiZarrToZarr\n",
+    "import xarray as xr\n",
+    "import dask\n",
+    "import hvplot.xarray\n",
+    "import zarr\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "177f18d3-53b9-4691-bc36-19632d20b448",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import warnings\n",
+    "warnings.filterwarnings(\"ignore\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "72931cdb-218f-42f6-a4b5-023a0e7a1549",
+   "metadata": {},
+   "source": [
+    "#### Use AWS environment variables for credentials\n",
+    "in this case to specify credentials that give write access to the 'esip-qhub' bucket"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "515d0863-6705-411e-94aa-048f3a36c4cf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "os.environ['AWS_PROFILE'] = 'esip-qhub'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e9ec55ae-77de-4209-8360-d2d25460c29c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_read = fsspec.filesystem('s3', anon=False, skip_instance_cache=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b9c6b31a-c2b6-48ec-9731-7a2f72a8dfcf",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_write = fs_read"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37cf61de-7fbc-4b72-a877-40a64062051f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "base_dir = 's3://esip-qhub/usgs/era5_land'\n",
+    "nc_files = f'{base_dir}/*.nc'\n",
+    "json_dir = f'{base_dir}/jsons/'\n",
+    "s3_ref_file = f'{base_dir}/archive.json'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "02c89bfe-17ed-4453-a230-9d5ac35483ec",
+   "metadata": {},
+   "source": [
+    "#### Process all NetCDF files not found in the list of JSON files.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ab8fba1b-541a-45a3-b091-53fdbed2adf4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc_list = fs_read.glob(nc_files)\n",
+    "print(len(nc_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "858055a4-4963-4c49-9203-0e4f2da3c6b3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "json_list = fs_read.glob(f'{json_dir}*.json')\n",
+    "print(len(json_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb74a84a-ccc3-40f9-b180-a5969b4f8823",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# fs_write.rm(json_list)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c107fdf8-b3eb-4944-9075-b7b4ef8e59f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc_processed_list = [j.split('.json')[0].replace('/jsons','') for j in json_list]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42d69305-3c28-4228-963e-99ac8775dbbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nc_process_list = list(set(nc_list) - set(nc_processed_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cf477e38-751c-4388-b182-ebc1fb766464",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(nc_process_list))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9550156a-3e6b-4607-b937-73def563c537",
+   "metadata": {},
+   "source": [
+    "#### Reprocess any NetCDF files that have been updated since we last wrote their JSON"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80293836-470c-474b-8b56-98e4b16521ea",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for i in range(len(json_list)):\n",
+    "    a = fs_read.info(json_list[i])['LastModified']\n",
+    "    b = fs_read.info(nc_processed_list[i])['LastModified']\n",
+    "    if b>a:\n",
+    "        nc_process_list.append(nc_processed_list[i])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85c4a5fd-bbe2-437e-8537-9489905fa12e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(len(nc_process_list))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff2ea828-1ce7-4781-b73e-fb8d4d4dc46b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "flist = sorted(['s3://'+f for f in nc_process_list])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "754bd605-a604-4556-8c7b-9e30b1901dd1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "so = dict(mode='rb', anon=False, profile='esip-qhub', skip_instance_cache=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c61c32d-f953-43d7-88e6-85b4719349c7",
+   "metadata": {},
+   "source": [
+    "#### Create the individual JSON files directly on S3 "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c31b04da-7f25-4630-b89d-7074aaa5f7bd",
+   "metadata": {},
+   "source": [
+    "We passed AWS credentials to the Dask workers via environment variables above, and the dask workers don't have the AWS credentials file with profiles defined, so we don't define a profile here, we just set `anon=False` and let the workers find the credentials via the environment variables:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52c6d5f0-556e-492a-9d2b-8e3aab26abdc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def gen_json(u):\n",
+    "    with fs_read.open(u, **so) as infile:\n",
+    "        h5chunks = SingleHdf5ToZarr(infile, u, inline_threshold=300)\n",
+    "        p = u.split('/')\n",
+    "        fname = p[-1]\n",
+    "        outf = f'{json_dir}{fname}.json'\n",
+    "        print(outf)\n",
+    "        with fs_write.open(outf, 'wb') as f:\n",
+    "            f.write(ujson.dumps(h5chunks.translate()).encode());"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "de820114-f2db-4f92-89d8-b9f3508e5e37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "gen_json(flist[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7401acd-f02c-4e53-ab2b-fca4877a1be0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u = flist[1]\n",
+    "p = u.split('/')\n",
+    "fname = p[-1]\n",
+    "outf = f'{json_dir}{fname}.json'\n",
+    "print(outf)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acf92f28-8ae8-4d6e-a39c-8114fc86bdf5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def configure_cluster(resource):\n",
+    "    ''' Helper function to configure cluster\n",
+    "    '''\n",
+    "    if resource == 'denali':\n",
+    "        cluster = LocalCluster(threads_per_worker=1)\n",
+    "        client = Client(cluster)\n",
+    "    \n",
+    "    elif resource == 'tallgrass':\n",
+    "        from dask_jobqueue import SLURMCluster\n",
+    "        cluster = SLURMCluster(queue='cpu', cores=1, interface='ib0',\n",
+    "                               job_extra=['--nodes=1', '--ntasks-per-node=1', '--cpus-per-task=1'],\n",
+    "                               memory='6GB')\n",
+    "        cluster.adapt(maximum_jobs=30)\n",
+    "        client = Client(cluster)\n",
+    "        \n",
+    "    elif resource == 'local':\n",
+    "        import os\n",
+    "        import warnings\n",
+    "        warnings.warn(\"Running locally can result in costly data transfers!\\n\")\n",
+    "        n_cores = os.cpu_count() # set to match your machine\n",
+    "        cluster = LocalCluster(threads_per_worker=n_cores)\n",
+    "        client = Client(cluster)\n",
+    "        \n",
+    "    elif resource in ['esip-qhub-gateway-v0.4']:   \n",
+    "        import sys, os\n",
+    "        sys.path.append(os.path.join(os.environ['HOME'],'shared','users','lib'))\n",
+    "        import ebdpy as ebd\n",
+    "        aws_profile = 'esip-qhub'\n",
+    "        ebd.set_credentials(profile=aws_profile)  # sets credentials for notebook\n",
+    "        aws_region = 'us-west-2'\n",
+    "        endpoint = f's3.{aws_region}.amazonaws.com'\n",
+    "        ebd.set_credentials(profile=aws_profile, region=aws_region, endpoint=endpoint)\n",
+    "        worker_max = 30\n",
+    "        client,cluster = ebd.start_dask_cluster(profile=aws_profile, worker_max=worker_max, \n",
+    "                                              region=aws_region, use_existing_cluster=True,\n",
+    "                                              adaptive_scaling=False, wait_for_cluster=False, \n",
+    "                                              worker_profile='Small Worker', propagate_env=True)\n",
+    "        \n",
+    "    return client, cluster"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "e3eb21c3-c309-4264-9bcb-758e15964647",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resource = 'esip-qhub-gateway-v0.4' #denali, tallgrass, local, esip-qhub-gateway-v0.4\n",
+    "client, cluster = configure_cluster(resource)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9c8f125e-5d24-45e9-b189-12104c5a277f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# _ = dask.compute(*[dask.delayed(gen_json)(f) for f in flist], retries=10);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b30fa5a-f9b9-45b0-86b6-35d1348750c9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cluster.scale(30)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44518f3f-ea86-422a-a98a-3f99e57fdcc0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "import dask.bag as db\n",
+    "b = db.from_sequence(flist, npartitions=30)\n",
+    "b = b.map(gen_json)\n",
+    "results = b.compute()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f2f78246-9b51-42d2-b72b-658e184892fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jsons = fs_write.ls(json_dir)\n",
+    "jsons = sorted(['s3://'+f for f in jsons])\n",
+    "print(len(jsons))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4c373e7d-3918-4679-9e15-3ab531941a4c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mzz = MultiZarrToZarr(jsons,   \n",
+    "    remote_protocol = 's3',\n",
+    "    remote_options={'anon':False},\n",
+    "    concat_dims = ['time'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "387c4ef4-c768-47c0-b73f-3005d75b8e47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "d = mzz.translate()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92657987-a861-483a-be75-dc2a74ed41e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fs = fsspec.filesystem(\"reference\", fo=d, ref_storage_args={'skip_instance_cache':True},\n",
+    "                       remote_protocol='s3', remote_options={'anon':False})\n",
+    "m = fs.get_mapper(\"\")\n",
+    "ds = xr.open_dataset(m, engine=\"zarr\", backend_kwargs={'consolidated':False}, chunks={})\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5f11b65b-a71e-4e92-8ece-a52496166067",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.data_vars"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6221fef8-5ca4-4ee2-9b6e-ae076b7949ec",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "local_consolidated_json = 'era5_land.json'\n",
+    "mzz.translate(local_consolidated_json)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4f458c1f-5b94-4d74-a14b-a97b5336f735",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s3_json = 's3://esip-qhub/usgs/era5_land/archive2.json'\n",
+    "_ = fs_write.upload(local_consolidated_json, s3_json)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cc2c4b87-0751-4264-a360-8e142955da0a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_write.info(s3_json)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81387808-d338-4e3c-9dfa-1857646c8d47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "fs_s3 = fsspec.filesystem(\"reference\", fo=s3_json, ref_storage_args={'skip_instance_cache':True},\n",
+    "                       remote_protocol='s3', remote_options={'anon':False})\n",
+    "m = fs_s3.get_mapper(\"\")\n",
+    "ds = xr.open_dataset(m, engine=\"zarr\", backend_kwargs={'consolidated':False}, chunks={})\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ef885f15-01b4-4e3b-a4c9-d85248761d95",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.sd.hvplot(x='longitude', y='latitude', cmap='turbo', rasterize=True, geo=True, tiles='ESRI')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ec4af76-a588-41d7-b997-e5b366bac98e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import intake\n",
+    "url = 'era5_intake.yml'\n",
+    "cat = intake.open_catalog(url)\n",
+    "list(cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "319b756a-acac-459a-a8e4-fb080e6ca36a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fs_write.upload(url, 's3://esip-qhub/usgs/era5_land/era5_intake.yml')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7c5f6b0-543d-4b46-9504-69f06ee06e06",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "url = 's3://esip-qhub/usgs/era5_land/era5_intake.yml'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "850c98a1-7b29-4cee-a32d-097a6c1555e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat = intake.open_catalog(url)\n",
+    "list(cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b13558ba-6c28-4c61-9fd3-f7de017c2378",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cat['era5-land']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6463ac78-0599-4d91-861f-a1bd85e3cef8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = cat['era5-land'].to_dask()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32723b76-113c-49f3-9faa-e3081ab5c4aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4758c2d4-87a5-4863-8bfb-0a082b459f8a",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "users-pangeo",
+   "language": "python",
+   "name": "conda-env-users-pangeo-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/dataset_preprocessing/demos/gridmet_processing_with_pynco.ipynb
+++ b/dataset_preprocessing/demos/gridmet_processing_with_pynco.ipynb
@@ -1,0 +1,440 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "be16708d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%javascript\n",
+    "IPython.notebook.kernel.restart()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ff1be096",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import fsspec\n",
+    "import os\n",
+    "import tempfile\n",
+    "import xarray as xr\n",
+    "\n",
+    "from nco import Nco\n",
+    "from nco.custom import Atted"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "118de47c-2b56-4348-905b-08b7a280f58a",
+   "metadata": {},
+   "source": [
+    "# Processing netCDF files\n",
+    "This notebook documents two approaches to processing netCDF files \n",
+    "with `pyNCO` (https://pynco.readthedocs.io/en/latest/). \n",
+    "The gridmet product (https://www.climatologylab.org/gridmet.html) is used for these examples. \n",
+    "The gridmet files contain one variable per year. This notebook shows examples of merging those files \n",
+    "into a single, multi-year file containing all variables.\n",
+    "\n",
+    "In the first approach the management of the temporary files is done manually. In this case care must be taken to \n",
+    "track the temporary files, avoiding file collisions (e.g. accidently overwriting temporary files) and removing \n",
+    "the files once processing is done.\n",
+    "\n",
+    "The second approach makes use of the `tempfile` library which automates the use and handling of the temporary \n",
+    "files needed during processing. Temporary files are automatically removed at the end of the processing."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "009eb9fc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Sample gridmet filename: 2020_gm_tmin_2021_03_31.nc\n",
+    "#     year ----------------^^^^\n",
+    "#     variable --------------------^^^^\n",
+    "#     date retrieved -------------------^^^^^^^^^^\n",
+    "\n",
+    "var = 'tmin'\n",
+    "base_dir = '/Volumes/USGS_NHM2/datasets/gridmet'\n",
+    "src_dir = f'{base_dir}/gridmet_raw'\n",
+    "output_dir = f'{base_dir}/test_output'\n",
+    "\n",
+    "output_filename = f'gridmet_{var}_1979-2020'    # .nc is added later"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6fe9cb10-364b-46f2-bcc7-72beebd47334",
+   "metadata": {},
+   "source": [
+    "## Using pyNCO with manual temporary file management"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4b79c94d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create NCO object\n",
+    "# Setting debug=True will output information about the nco execution that can be useful\n",
+    "# when examining problems in the processing scripts.\n",
+    "nco = Nco(debug=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43fc5bd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open a filesystem\n",
+    "fs = fsspec.filesystem('file')\n",
+    "\n",
+    "# Build list of gridmet files\n",
+    "flist = sorted(fs.glob(f'{src_dir}/*_gm_{var}_*.nc'))\n",
+    "print(flist[0])\n",
+    "print(flist[-1])\n",
+    "len(flist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "8bb82522",
+   "metadata": {},
+   "source": [
+    "NOTE (2022-01): This notebook works from the original retrieved Gridmet data (on denali). \n",
+    "This data was saved in netCDF Classic format but still included the _ChunkSizes attribute which \n",
+    "confuses some tools. Removing the attribute can be done in-place if you have read-write access to the files; \n",
+    "otherwise you have to make a copy of the original files without the _ChunkSizes attribute. \n",
+    "More recent versions of the gridmet data do not have this problem."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83bc649a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Original NCO command\n",
+    "# ncatted -a _ChunkSizes,,d,, ${ff}\n",
+    "\n",
+    "# opts = ['-a _ChunkSizes,,d,,']\n",
+    "# nco.ncatted(input=somefile.nc)\n",
+    "\n",
+    "opts = ['-h', Atted(mode='delete', att_name='_ChunkSizes')]\n",
+    "\n",
+    "for ff in flist[0:2]:\n",
+    "    nco.ncatted(input=ff, options=opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3b67e258-94a8-4aa6-a7a8-5f766bfd077f",
+   "metadata": {},
+   "source": [
+    "### Change fixed time dimension to record dimension"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "283d198e",
+   "metadata": {},
+   "source": [
+    "The original Gridmet data has a fixed time dimension named `day`. In order to concatenate individual files \n",
+    "(1 year, 1 variable per file) into a single file per variable for the period of record we need to change the \n",
+    "fixed time dimension into an unlimited record dimension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27e339c0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# ncks -O --mk_rec_dmn day ${ff} -o merged/${ff}\n",
+    "\n",
+    "# Adding -h prevents adding entries into the global history\n",
+    "record_dim = 'day'\n",
+    "opts = [f'-O -h --mk_rec_dmn {record_dim}']\n",
+    "\n",
+    "for ff in flist[0:2]:\n",
+    "    tmp_file = f'tmp_{os.path.basename(ff)}'\n",
+    "    print(f'Processing {tmp_file}')\n",
+    "    \n",
+    "    nco.ncks(input=ff, output=f'{output_dir}/{tmp_file}', options=opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7b295604-2f24-42ad-bb93-88e21949da71",
+   "metadata": {},
+   "source": [
+    "### Concatenate single-year files into a single multi-year file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cdf764d4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# ncrcat ${var}.nc -o gridmet_${var}_1979-2020.nc\n",
+    "\n",
+    "o_flist = sorted(fs.glob(f'{output_dir}/*.nc'))\n",
+    "\n",
+    "# The -h option prevents the netCDF operators tools from automatically appending to the \n",
+    "# global history attribute. Otherwise the history can get rather large and messy.\n",
+    "opts = ['-h']\n",
+    "\n",
+    "nco.ncrcat(input=o_flist, output=f'{output_dir}/{var}.nc', options=opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4edbd458-5ba0-434f-a358-63d962cb948d",
+   "metadata": {},
+   "source": [
+    "### Create simplified global history"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5905d2b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Construct a simplified/sanitized history entry\n",
+    "input_files = ' '.join([os.path.basename(ff) for ff in o_flist])\n",
+    "history_text = f'ncrcat {input_files} -o {var}.nc'\n",
+    "\n",
+    "opts = ['-h', Atted(mode='append', att_name='history', var_name='global', value=history_text, stype='c')]\n",
+    "\n",
+    "# When only the input argument is specified for the ncatted command the\n",
+    "# attribute editing is done in-place.\n",
+    "xx = nco.ncatted(input=f'{output_dir}/{var}.nc', options=opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b9fcae88",
+   "metadata": {},
+   "source": [
+    "### Rechunk the concatenated file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70bc64c9",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# ncks -O -4 -L 2 --cnk_map=dmn --cnk_dmn day,122 --cnk_dmn lat,98 --cnk_dmn lon,231 ${ff} -o ../${ff}\n",
+    "time_cnk = 122\n",
+    "lat_cnk = 98\n",
+    "lon_cnk = 231\n",
+    "\n",
+    "opts = ['-O', '-4', '-L 2', \n",
+    "        '--cnk_map=dmn', \n",
+    "        f'--cnk_dmn {record_dim},{time_cnk}',\n",
+    "        f'--cnk_dmn lat,{lat_cnk}', \n",
+    "        f'--cnk_dmn lon,{lon_cnk}']\n",
+    "\n",
+    "nco.ncks(input=f'{output_dir}/{var}.nc', output=f'{output_dir}/{output_filename}.nc', options=opts)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9f2fee40-b32f-42aa-ae43-119330a72d2a",
+   "metadata": {},
+   "source": [
+    "### Explore the merged netCDF file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5baa9ee7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.open_dataset(f'{output_dir}/{output_filename}.nc', chunks='auto')\n",
+    "ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "83d0492d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examine one of the variables\n",
+    "ds.daily_minimum_temperature"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46771256",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds.attrs.keys()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5eafc689",
+   "metadata": {},
+   "source": [
+    "# Using pyNCO with automatic temporary file management"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5fd0b61e",
+   "metadata": {},
+   "source": [
+    "Here we create a temporary directory to contain the intermediate files. The directory and its contents are \n",
+    "automatically removed once the code block has completed. The final output file is written to the output directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a795bd61",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "# When clean_history is true the original global history attribute contents are cleared and replaced with\n",
+    "# only the history related to our processing.\n",
+    "clean_history = True\n",
+    "\n",
+    "with tempfile.TemporaryDirectory() as tmp_dir:\n",
+    "    print(f'Working in {tmp_dir}')\n",
+    "    \n",
+    "    # Make the time dimension a record dimension\n",
+    "    print('    Make record dimension')\n",
+    "    record_dim = 'day'\n",
+    "    opts = [f'-O --mk_rec_dmn {record_dim}']\n",
+    "\n",
+    "    for ff in flist[0:2]:\n",
+    "        tmp_filename = f'tmp_{os.path.basename(ff)}'\n",
+    "        print(f'Processing {tmp_filename}')\n",
+    "\n",
+    "        nco.ncks(input=ff, output=f'{tmp_dir}/{tmp_filename}', options=opts)\n",
+    "        \n",
+    "    # Concatenate the individual files\n",
+    "    print('    Concatenate files')\n",
+    "    o_flist = sorted(fs.glob(f'{tmp_dir}/*.nc'))\n",
+    "\n",
+    "    nco.ncrcat(input=o_flist, output=f'{tmp_dir}/{var}_concat.nc')   # , options=opts)        \n",
+    "        \n",
+    "    # Rechunk the data\n",
+    "    print('    Rechunk data')\n",
+    "    time_cnk = 122\n",
+    "    lat_cnk = 98\n",
+    "    lon_cnk = 231\n",
+    "\n",
+    "    opts = ['-O', '-4', '-L 2', \n",
+    "            '--cnk_map=dmn', \n",
+    "            f'--cnk_dmn {record_dim},{time_cnk}',\n",
+    "            f'--cnk_dmn lat,{lat_cnk}', \n",
+    "            f'--cnk_dmn lon,{lon_cnk}']\n",
+    "\n",
+    "    nco.ncks(input=f'{tmp_dir}/{var}_concat.nc', output=f'{output_dir}/{output_filename}.nc', options=opts)\n",
+    "    \n",
+    "    if clean_history:\n",
+    "        print('    Clean history')\n",
+    "        # Read the final file and create a modified history\n",
+    "        ds = xr.open_dataset(f'{output_dir}/{output_filename}.nc', chunks='auto')\n",
+    "\n",
+    "        history = ds.attrs['History']\n",
+    "        aa = history.split('\\n')\n",
+    "\n",
+    "        new_hist = []\n",
+    "\n",
+    "        for io, dd in enumerate(aa):\n",
+    "            bb = dd.split()\n",
+    "            keep = True\n",
+    "\n",
+    "            for ii, cc in enumerate(bb):\n",
+    "                if cc in ['ncatted']:\n",
+    "                    keep = False\n",
+    "                    continue\n",
+    "                elif '--output' in cc:\n",
+    "                    bb[ii] = '--output=' + os.path.basename(cc.split('=')[1])\n",
+    "                else:\n",
+    "                    if os.path.isfile(cc):\n",
+    "                        bb[ii] = os.path.basename(cc)\n",
+    "            if keep:\n",
+    "                new_hist.append(' '.join(bb))\n",
+    "\n",
+    "        ds.close()\n",
+    "        \n",
+    "        # Remove History global attribute\n",
+    "        opts = ['-h', Atted(mode='delete', att_name='History', var_name='global')]\n",
+    "        nco.ncatted(input=f'{output_dir}/{output_filename}.nc', options=opts)        \n",
+    "        \n",
+    "        # Add new history global attribute (all lowercase)\n",
+    "        # NOTE: the double backslash for the value argument is needed so that \\n is passed to ncatted correctly\n",
+    "        opts = ['-h', Atted(mode='create', att_name='history', var_name='global', \n",
+    "                            value='\\\\n'.join(new_hist), stype='c')]\n",
+    "        nco.ncatted(input=f'{output_dir}/{output_filename}.nc', options=opts)        "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a7aa938d",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "formats": "ipynb,py:percent"
+  },
+  "kernelspec": {
+   "display_name": "Python [conda env:nco]",
+   "language": "python",
+   "name": "conda-env-nco-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This pull request transfers over the contents of https://github.com/USGS-python/hytest-development/tree/main/data-preprocessing into the dataset_preprocessing folder.

The files were organized as follows:
- demos:
  - [all notebooks in era5 folder](https://github.com/USGS-python/hytest-development/tree/main/data-preprocessing/era5)
  - [notebook in gridmet folder](https://github.com/USGS-python/hytest-development/tree/main/data-preprocessing/gridmet)
- archive:
  - [conus404_to_zarr](https://github.com/USGS-python/hytest-development/tree/main/data-preprocessing/conus404_to_zarr) (renamed as `conus404_subset_to_zarr`)

@rsignell-usgs - can you confirm that the items in the demos folder are just demos and not datasets that we are providing any formal access to?

We are not including [this notebook](https://github.com/USGS-python/hytest-development/tree/main/data-preprocessing) can because it is succeeded by [this one](https://github.com/USGS-python/hytest-evaluation-workflows/blob/main/gallery/streamflow/01_nwm_benchmark_preprocessing.ipynb) which has already been merged in to the dataset_preprocessing/tutorials folder.