### PR TITLE
HPC instructions

### DIFF
--- a/environment_set_up/JupyterForward.md
+++ b/environment_set_up/JupyterForward.md
@@ -19,6 +19,7 @@ The [jupyter-forward](https://pypi.org/project/jupyter-forward/) software will
 wrap up a series of commands necessary to to execute a jupyter server on the
 HPC host we just configured. It is a convenience package intended to make
 HPC-based jupyter servers easy.
+
     * Install Python on your PC. <br>
       You will need to have python installed on your PC, along with either `pip` or
       `conda` to help manage the python environments. We recommend anaconda.
@@ -35,14 +36,16 @@ HPC-based jupyter servers easy.
    With all of that set up, you are now ready to launch a session on the HPC using
    `jupyter-forward` on your PC. Do this every time you would like to run notebooks
    housed on the HPC host.
+
     * Launch an `Anaconda Shell` from your start menu
     * Run `jupyter-forward denali`
     * NOTE: This command will run the jupter server on the **login node** of Denali.
       This is OK if your workload is light (i.e. for tutorials).  If you will be doing
       heavier processing:
-```text
-jupyter-forward --launch-command "srun -A acctname -N 1 -t 02:00:00"  denali
-```
+
+  ```text
+    jupyter-forward --launch-command "srun -A acctname -N 1 -t 02:00:00"  denali
+  ```
 
 ## 4) Shut Down Server<br>
 

--- a/environment_set_up/JupyterForward.md
+++ b/environment_set_up/JupyterForward.md
@@ -1,0 +1,51 @@
+# HPC Server :: Jupyter Forward
+
+This option will configure your HPC account to access the correct Jupyter server software.  That server
+will be invoked by a command installed on your PC.  This option minimizes the configuration changes
+needed on the HPC host, but still permits relatively easy access to that hardware via a personal Jupyter
+Server.
+
+## 1) Configure your HPC account to access the HyTEST [conda](www.anaconda.org) environment :
+
+    * log in to either HPC host ( `denali` or `tallgrass` )
+    * Execute this command:  ` echo "module load hytest" >> ~/.bashrc"
+    * NOTE.  It is **critical** that the above command uses the double-greater-than.  If you accidentally just use a single,
+      bad things will happen.
+
+## 2) Install `jupyter-forward` on your PC.
+
+This is a one-time operation to get the right software on your desktop.
+The [jupyter-forward](https://pypi.org/project/jupyter-forward/) software will
+wrap up a series of commands necessary to to execute a jupyter server on the
+HPC host we just configured. It is a convenience package intended to make
+HPC-based jupyter servers easy.
+    * Install Python on your PC. <br>
+      You will need to have python installed on your PC, along with either `pip` or
+      `conda` to help manage the python environments. We recommend anaconda.
+      You can request anaconda from IT, or you can download the installer from [anaconda.com](https://www.anaconda.com/)
+      to install it in user space (i.e. admin is not required).
+    * Add `jupyter-forward` to your PC:<br>
+      Launch an `Anaconda Shell` from your Start menu, then execute:
+      ```text
+      > conda install -c conda-forge jupyter-forward
+      ```
+
+## 3) Launch Server
+
+   With all of that set up, you are now ready to launch a session on the HPC using
+   `jupyter-forward` on your PC. Do this every time you would like to run notebooks
+   housed on the HPC host.
+    * Launch an `Anaconda Shell` from your start menu
+    * Run `jupyter-forward denali`
+    * NOTE: This command will run the jupter server on the **login node** of Denali.
+      This is OK if your workload is light (i.e. for tutorials).  If you will be doing
+      heavier processing:
+```text
+jupyter-forward --launch-command "srun -A acctname -N 1 -t 02:00:00"  denali
+```
+
+## 4) Shut Down Server<br>
+
+After a daily session, you will need to shut down the jupyter server.
+In the terminal session where you started `jupyter-forward`, merely press Ctl-C
+to signal the server to shut down.

--- a/environment_set_up/OpenOnDemand.md
+++ b/environment_set_up/OpenOnDemand.md
@@ -1,0 +1,18 @@
+# HPC Server :: Open OnDemand
+
+This is a custom service provided by the ARC team and customized for use in HyTEST workflows. It is the easiest
+to use (no configuration needed on your part), and provides reasonable compute resources via the `tallgrass`
+host:
+
+* Go to `https://tallgrass-denali-ondemand.cr.usgs.gov/pun/sys/dashboard/` in your web browser.  Note that you
+  must be on the VPN to access this host.
+* Launch the HyTEST Jupter Server app
+* Fill in the form to customize the allocation in which the Jupyter Server will execute.
+* Submit
+
+The Jupyter Server will run in an allocation on `tallgrass`. This server will have access to your home
+directory/folder on that host, which is where your notebooks will reside.
+
+For light duty work (i.e. tutorials), a `Viz` node is likely adequate in your allocation request.  If you
+will be doing heavier processing, you may want to request a compute node.  None of the HyTEST tutorials
+utilize GPU code; a GPU-enabled node is not necessary.

--- a/environment_set_up/OpenOnDemand.md
+++ b/environment_set_up/OpenOnDemand.md
@@ -6,7 +6,7 @@ host:
 
 * Go to `https://tallgrass-denali-ondemand.cr.usgs.gov/pun/sys/dashboard/` in your web browser.  Note that you
   must be on the VPN to access this host.
-* Launch the HyTEST Jupter Server app
+* Launch the HyTEST Jupyter Server app (NOTE: this is a work-in-progress; if it's not there now, it is expected soon.)
 * Fill in the form to customize the allocation in which the Jupyter Server will execute.
 * Submit
 

--- a/environment_set_up/README.md
+++ b/environment_set_up/README.md
@@ -17,3 +17,6 @@ options, in increasing order of complexity and flexibility:
    This option lets you completely customize your HPC compute environment and invoke the Jupyter
    server from a command shell on the HPC. Requires familiarity with the HPC command line, file
    editing, etc.
+
+If your workflow makes use of parallelism using Dask on HPC hosts, read [this](./tallgrass_dask-jobqueue.md)
+for information about how to configure the Slurm job scheduler within your notebook.

--- a/environment_set_up/README.md
+++ b/environment_set_up/README.md
@@ -1,85 +1,19 @@
 # HPC Environment
 
 While these tutorial notebooks are intended for use on "_cloud_" infrastructure, it is possible to run them
-on HPC hardware also.  Some notebooks will need modifications specific to the compute cluster hardware. You
-will also need to access an enviroment which emulates the Jupyter server -- where the notebooks will reside
-and execute -- using the HPC hardware. There are many ways to do this. Here are three options, in increasing
-order of complexity and flexibility:
+on HPC hardware also.  Some notebooks will need modifications specific to the compute cluster hardware.
+More importantly, you will also need to access an enviroment which emulates the Jupyter server -- where the
+notebooks will reside and execute -- using the HPC hardware. There are many ways to do this. Here are three
+options, in increasing order of complexity and flexibility:
 
-## Open OnDemand
-
-This is a custom service provided by the ARC team and customized for use in HyTEST workflows. It is the easiest
-to use (no configuration needed on your part), and provides reasonable compute resources via the `tallgrass`
-host:
-
-* Go to `https://tallgrass-denali-ondemand.cr.usgs.gov/pun/sys/dashboard/` in your web browser.  Note that you
-  must be on the VPN to access this host.
-* Launch the HyTEST Jupter Server app
-* Fill in the form to customize the allocation in which the Jupyter Server will execute.
-* Submit
-
-The Jupyter Server will run in an allocation on `tallgrass`. This server will have access to your home
-directory/folder on that host, which is where your notebooks will reside.
-
-## Jupyter-Forward
-
-This option will configure your HPC account to access the correct Jupyter server software.  That server
-will be invoked by a command installed on your PC.  This option minimizes the configuration changes
-needed on the HPC host, but still permits relatively easy access to that hardware via a personal Jupyter
-Server.
-
-1) Configure your HPC account to access the HyTEST [conda](www.anaconda.org) environment :
-    * log in to either HPC host ( `denali` or `tallgrass` )
-    * Execute this command:  ` echo "module load hytest" >> ~/.bashrc"
-    * NOTE.  It is **critical** that the above command uses the double-greater-than.  If you accidentally just use a single,
-      bad things will happen.
-2) Install `jupyter-forward` on your PC.  <br>
-    This is a one-time operation to get the right software on your desktop.
-    The [jupyter-forward](https://pypi.org/project/jupyter-forward/) software will
-    wrap up a series of commands necessary to to execute a jupyter server on the
-    HPC host we just configured. It is a convenience package intended to make
-    HPC-based jupyter servers easy.
-    * Install Python on your PC. <br>
-      You will need to have python installed on your PC, along with either `pip` or
-      `conda` to help manage the python environments. We recommend anaconda.
-      You can request anaconda from IT, or you can download the installer from [anaconda.com](https://www.anaconda.com/)
-      to install it in user space (i.e. admin is not required).
-    * Add `jupyter-forward` to your PC:<br>
-      Launch an `Anaconda Shell` from your Start menu, then execute:
-      ```text
-      > conda install -c conda-forge jupyter-forward
-      ```
-3) Launch Server<br>
-   With all of that set up, you are now ready to launch a session on the HPC using
-   `jupyter-forward` on your PC. Do this every time you would like to run notebooks
-   housed on the HPC host.
-    * Launch an `Anaconda Shell` from your start menu
-    * Run `jupyter-forward denali`
-    * NOTE: This command will run the jupter server on the **login node** of Denali.
-      This is OK if your workload is light (i.e. for tutorials).  If you will be doing
-      heavier processing:
-```text
-jupyter-forward --launch-command "srun -A acctname -N 1 -t 02:00:00"  denali
-```
-
-4) Shut Down Server<br>
-After a daily session, you will need to shut down the jupyter server.
-In the terminal session where you started `jupyter-forward`, merely press Ctl-C
-to signal the server to shut down.
-
-## Manual Launch
-
-Use this option if you would like more control over the allocation request and the environment in which the jupyter server runs.
-This option requires that you log into the HPC host to run a custom script.  Doing so will launch your custom jupyter server
-and plumb the port forwarding necessary to make it available to your desktop web browser.
-
-1) Log in to your HPC host
-2) Execute the [jupyter-start.sh](./jupter-start.sh) script
-3) Follow its instructions
-
-The `jupyter-start.sh` script will direct you on how to set up port forwarding (that's the `ssh` command to run
-from your PC's command prompt) and will provide the URL where your PC's browser will find the jupter server.
-
-This option can be useful if you want to build your own conda environment, rather than using the provided
-HyTEST environment.  If you choose to do that, you will want to edit the `jupyter-start.sh` script to reflect
-the change in environment location. 
+1) [Open OnDemand](./OpenOnDemand.md)<br>
+   Provides the most effortless access to HPC hardware using a web interface (not unlike the
+   ESIP/QHUB interface). Only runs on `tallgrass`.
+2) [Jupyter Forward](./JupyterForward.md)<br>
+   This option gives you more control over how to launch the server, and on which host (can be
+   run on `denali`, `tallgrass`, or other hosts to which you have a login).  Requires that you
+   install an extra bit of software on your PC.
+3) [Custom Server Script](./StartScript.md)<br>
+   This option lets you completely customize your HPC compute environment and invoke the Jupyter
+   server from a command shell on the HPC. Requires familiarity with the HPC command line, file
+   editing, etc.

--- a/environment_set_up/README.md
+++ b/environment_set_up/README.md
@@ -1,0 +1,85 @@
+# HPC Environment
+
+While these tutorial notebooks are intended for use on "_cloud_" infrastructure, it is possible to run them
+on HPC hardware also.  Some notebooks will need modifications specific to the compute cluster hardware. You
+will also need to access an enviroment which emulates the Jupyter server -- where the notebooks will reside
+and execute -- using the HPC hardware. There are many ways to do this. Here are three options, in increasing
+order of complexity and flexibility:
+
+## Open OnDemand
+
+This is a custom service provided by the ARC team and customized for use in HyTEST workflows. It is the easiest
+to use (no configuration needed on your part), and provides reasonable compute resources via the `tallgrass`
+host:
+
+* Go to `https://tallgrass-denali-ondemand.cr.usgs.gov/pun/sys/dashboard/` in your web browser.  Note that you
+  must be on the VPN to access this host.
+* Launch the HyTEST Jupter Server app
+* Fill in the form to customize the allocation in which the Jupyter Server will execute.
+* Submit
+
+The Jupyter Server will run in an allocation on `tallgrass`. This server will have access to your home
+directory/folder on that host, which is where your notebooks will reside.
+
+## Jupyter-Forward
+
+This option will configure your HPC account to access the correct Jupyter server software.  That server
+will be invoked by a command installed on your PC.  This option minimizes the configuration changes
+needed on the HPC host, but still permits relatively easy access to that hardware via a personal Jupyter
+Server.
+
+1) Configure your HPC account to access the HyTEST [conda](www.anaconda.org) environment :
+    * log in to either HPC host ( `denali` or `tallgrass` )
+    * Execute this command:  ` echo "module load hytest" >> ~/.bashrc"
+    * NOTE.  It is **critical** that the above command uses the double-greater-than.  If you accidentally just use a single,
+      bad things will happen.
+2) Install `jupyter-forward` on your PC.  <br>
+    This is a one-time operation to get the right software on your desktop.
+    The [jupyter-forward](https://pypi.org/project/jupyter-forward/) software will
+    wrap up a series of commands necessary to to execute a jupyter server on the
+    HPC host we just configured. It is a convenience package intended to make
+    HPC-based jupyter servers easy.
+    * Install Python on your PC. <br>
+      You will need to have python installed on your PC, along with either `pip` or
+      `conda` to help manage the python environments. We recommend anaconda.
+      You can request anaconda from IT, or you can download the installer from [anaconda.com](https://www.anaconda.com/)
+      to install it in user space (i.e. admin is not required).
+    * Add `jupyter-forward` to your PC:<br>
+      Launch an `Anaconda Shell` from your Start menu, then execute:
+      ```text
+      > conda install -c conda-forge jupyter-forward
+      ```
+3) Launch Server<br>
+   With all of that set up, you are now ready to launch a session on the HPC using
+   `jupyter-forward` on your PC. Do this every time you would like to run notebooks
+   housed on the HPC host.
+    * Launch an `Anaconda Shell` from your start menu
+    * Run `jupyter-forward denali`
+    * NOTE: This command will run the jupter server on the **login node** of Denali.
+      This is OK if your workload is light (i.e. for tutorials).  If you will be doing
+      heavier processing:
+```text
+jupyter-forward --launch-command "srun -A acctname -N 1 -t 02:00:00"  denali
+```
+
+4) Shut Down Server<br>
+After a daily session, you will need to shut down the jupyter server.
+In the terminal session where you started `jupyter-forward`, merely press Ctl-C
+to signal the server to shut down.
+
+## Manual Launch
+
+Use this option if you would like more control over the allocation request and the environment in which the jupyter server runs.
+This option requires that you log into the HPC host to run a custom script.  Doing so will launch your custom jupyter server
+and plumb the port forwarding necessary to make it available to your desktop web browser.
+
+1) Log in to your HPC host
+2) Execute the [jupyter-start.sh](./jupter-start.sh) script
+3) Follow its instructions
+
+The `jupyter-start.sh` script will direct you on how to set up port forwarding (that's the `ssh` command to run
+from your PC's command prompt) and will provide the URL where your PC's browser will find the jupter server.
+
+This option can be useful if you want to build your own conda environment, rather than using the provided
+HyTEST environment.  If you choose to do that, you will want to edit the `jupyter-start.sh` script to reflect
+the change in environment location. 

--- a/environment_set_up/StartScript.md
+++ b/environment_set_up/StartScript.md
@@ -1,0 +1,23 @@
+# HPC Server :: Start Script
+
+
+Use this option if you would like more control over the allocation request and the environment in
+which the jupyter server runs. This option requires that you log into the HPC host to run a custom
+script.  Copy [this example](./jupter-start.sh) and edit to your liking.
+
+Launching in this way will start your custom jupyter server and plumb the port forwarding necessary
+to make it available to your desktop web browser.
+
+1) Log in to your HPC host
+2) Execute the [jupyter-start.sh](./jupter-start.sh) script
+3) Follow its instructions
+
+The `jupyter-start.sh` script will direct you on how to start port forwarding (that's the `ssh` command to run
+from your PC's command prompt) and will provide the URL where your PC's browser will find the jupter server.
+
+This option can be useful if you want to build your own conda environment, rather than using the provided
+HyTEST environment. The [Pangeo docs](https://pangeo.io/setup_guides/hpc.html) are a good place to start
+if you would like to set up your own environment using this start script.
+
+If you choose to do that, you will want to edit the `jupyter-start.sh` script to reflect
+the particulars of your custom conda environment.

--- a/environment_set_up/StartScript.md
+++ b/environment_set_up/StartScript.md
@@ -17,7 +17,9 @@ from your PC's command prompt) and will provide the URL where your PC's browser 
 
 This option can be useful if you want to build your own conda environment, rather than using the provided
 HyTEST environment. The [Pangeo docs](https://pangeo.io/setup_guides/hpc.html) are a good place to start
-if you would like to set up your own environment using this start script.
+if you would like to set up your own environment using this start script.  The central HyTEST environment
+is built using [this](./HyTEST.yml) environment definition. We recommend that you
+use it as the baseline if you will be building your own environment.
 
 If you choose to do that, you will want to edit the `jupyter-start.sh` script to reflect
 the particulars of your custom conda environment.

--- a/environment_set_up/jupter-start.sh
+++ b/environment_set_up/jupter-start.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+## Set options for the SLURM scheduler -- edit as appropriate
+#SBATCH -J jupyternb
+#SBATCH -t 2-00:00:00
+#SBATCH -o %j-jupyternb.out
+#SBATCH -p workq
+#SBATCH -A wbeep
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=40
+
+# We will launch the server on a randomly assigned port number between 8400 and 9400.  This
+# minimizes the chances that we will impact other jupyter servers running at the same time.
+JPORT=`shuf -i 8400-9400 -n 1`
+
+### this will load the centralized HyTEST conda environment.
+module load hytest
+
+### If you want to use your own conda environment, remove the above module load statement
+### and include statements here to activate your own environment:
+# export PATH=/path/to/your/conda/bin:$PATH
+# source activate envname
+
+echo
+echo "##########################################################################"
+echo "Run the following ssh command from a new terminal on your desktop"
+echo "ssh -N -L $JPORT:`hostname`:$JPORT -L 8787:`hostname`:8787 $USER@denali.cr.usgs.gov"
+echo "##########################################################################"
+echo
+
+echo
+echo "##########################################################################"
+echo "COPY and paste the 127.0.0.1 URL below into a browser on your desktop"
+echo "##########################################################################"
+echo
+
+srun jupyter lab --ip '*' --no-browser --port $JPORT --notebook-dir $PWD

--- a/environment_set_up/manifest.txt
+++ b/environment_set_up/manifest.txt
@@ -1,8 +1,0 @@
-VERSION
-environment_set_up/auto-conf.py
-environment_set_up/HyTEST.yml
-environment_set_up/ManualConfig-HPC.md
-environment_set_up/QuickStart-Cloud.md
-environment_set_up/QuickStart-HPC.md
-environment_set_up/start_jupyter.sh
-README.md


### PR DESCRIPTION
Closes #91 

We have a few options for helping users get an HPC environment spun up.  Which do we recommend? Which are we willing to support for all users? 

I put together a set of instructions that lets the user choose which they want to use. These instructions assume that the ARC folks come through as expected to expose the `hytest` module to all users. 

In all cases, I have steered away from having the user install conda for themselves. But I make reference to that possibility and link to the Pangeo docs on that subject, if a user would really like to pursue it. 

This set of docs depends on the last installation steps from Lopaka... so we should merge this only after he's done his bits and the instructions become valid.  Until then, tho, I would find it useful to have a team discussion as to whether this is the right direction.

