### PR TITLE
update intake catalog to differentiate daily average and instantaneous

### DIFF
--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -16,22 +16,38 @@ sources:
       storage_options:
         requester_pays: true
         
-  conus404-daily-onprem:
+  conus404-daily-average-onprem:
     driver: zarr
-    description: "CONUS404 Hydro Variable subset, 40 years of daily data on Caldera on prem storage"
+    description: "CONUS404 Hydro Variable subset, 40 years of daily average values on Caldera on prem storage"
     args:
       urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily.zarr/'
       consolidated: true  
-        
-  conus404-daily-cloud:
+
+  conus404-daily-instantaneous-onprem:
     driver: zarr
-    description: "CONUS404 Hydro Variables subset, 40 years of daily values on Cloud"
+    description: "CONUS404 Hydro Variable subset, 40 years of daily instantaneous values on Caldera on prem storage"
     args:
-      urlpath: 's3://nhgf-development/conus404/conus404_daily.zarr'
+      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily_xtrm.zarr/'
+      consolidated: true  
+
+  conus404-daily-average-cloud:
+    driver: zarr
+    description: "CONUS404 Hydro Variables subset, 40 years of daily average values on Cloud"
+    args:
+      urlpath: 's3://nhgf-development/conus404/conus404_daily_202210.zarr/'
       consolidated: true
       storage_options:
         requester_pays: true
-        
+
+  conus404-daily-instantaneous-cloud:
+    driver: zarr
+    description: "CONUS404 Hydro Variables subset, 40 years of daily instantaneous values on Cloud"
+    args:
+      urlpath: 's3://nhgf-development/conus404/conus404_daily.zarr/'
+      consolidated: true
+      storage_options:
+        requester_pays: true
+
   nwis-streamflow-usgs-gages-onprem:
     driver: zarr
     description: "Streamflow from NWIS, extracted and rechunked into time series (NWM2.1 time period)"

--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -16,32 +16,32 @@ sources:
       storage_options:
         requester_pays: true
         
-  conus404-daily-average-onprem:
+  conus404-daily-onprem:
     driver: zarr
-    description: "CONUS404 Hydro Variable subset, 40 years of daily average values on Caldera on prem storage"
+    description: "CONUS404 40 years of daily values for subset of model output variables derived from hourly values on Caldera on-premise storage"
     args:
       urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily.zarr/'
       consolidated: true  
 
-  conus404-daily-instantaneous-onprem:
+  conus404-daily-diagnostic-onprem:
     driver: zarr
-    description: "CONUS404 Hydro Variable subset, 40 years of daily instantaneous values on Caldera on prem storage"
+    description: "CONUS404 40 years of daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10) on Caldera on-premise storage"
     args:
       urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily_xtrm.zarr/'
       consolidated: true  
 
-  conus404-daily-average-cloud:
+  conus404-daily-cloud:
     driver: zarr
-    description: "CONUS404 Hydro Variables subset, 40 years of daily average values on Cloud"
+    description: "CONUS404 40 years of daily values for subset of model output variables derived from hourly values on cloud storage"
     args:
       urlpath: 's3://nhgf-development/conus404/conus404_daily_202210.zarr/'
       consolidated: true
       storage_options:
         requester_pays: true
 
-  conus404-daily-instantaneous-cloud:
+  conus404-daily-diagnostic-cloud:
     driver: zarr
-    description: "CONUS404 Hydro Variables subset, 40 years of daily instantaneous values on Cloud"
+    description: "CONUS404 40 years of daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10) on cloud storage"
     args:
       urlpath: 's3://nhgf-development/conus404/conus404_daily.zarr/'
       consolidated: true


### PR DESCRIPTION
Note that I changed the intake catalog entry names - we were previously pointing to both daily instantaneous (on S3) and daily average (on Caldera) data and calling them both just "daily". This update will break notebooks, but I can't think of a better solution.

Tagging @pnorton-usgs and @rsignell-usgs as reviewers to make sure I've identified these correctly.