### PR TITLE
update nwm data location to osn-renc

### DIFF
--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -75,10 +75,8 @@ sources:
     driver: zarr
     description: "Streamflow from NWIS, extracted and rechunked into time series (NWM2.1 time period)"
     args:
-      urlpath: 's3://nhgf-development/nwm/nwis_chanobs.zarr'
+      urlpath: 'https://renc.osn.xsede.org/rsignellbucket2/hytest/nwm/nwis_chanobs.zarr'
       consolidated: true
-      storage_options:
-        requester_pays: true
       
   nwm21-streamflow-usgs-gages-onprem:
     driver: zarr
@@ -91,10 +89,8 @@ sources:
     driver: zarr
     description: "Streamflow from NWM2.1, extracted and rechunked into time series"
     args:
-      urlpath: 's3://nhgf-development/nwm/chanobs.zarr'
+      urlpath: 'https://renc.osn.xsede.org/rsignellbucket2/hytest/nwm/chanobs.zarr'
       consolidated: true
-      storage_options:
-        requester_pays: true
       
   nwm21-streamflow-cloud:
     driver: zarr

--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -75,8 +75,13 @@ sources:
     driver: zarr
     description: "Streamflow from NWIS, extracted and rechunked into time series (NWM2.1 time period)"
     args:
-      urlpath: 'https://renc.osn.xsede.org/rsignellbucket2/hytest/nwm/nwis_chanobs.zarr'
+      urlpath: 's3://rsignellbucket2/hytest/nwm/nwis_chanobs.zarr'
       consolidated: true
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://renc.osn.xsede.org
       
   nwm21-streamflow-usgs-gages-onprem:
     driver: zarr

--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -94,8 +94,13 @@ sources:
     driver: zarr
     description: "Streamflow from NWM2.1, extracted and rechunked into time series"
     args:
-      urlpath: 'https://renc.osn.xsede.org/rsignellbucket2/hytest/nwm/chanobs.zarr'
+      urlpath: 's3://rsignellbucket2/hytest/nwm/chanobs.zarr'
       consolidated: true
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://renc.osn.xsede.org
       
   nwm21-streamflow-cloud:
     driver: zarr


### PR DESCRIPTION
`chanobs.zarr` and `nwis_chanobs.zarr` have both been transferred to the OSN pod, so I updated the paths in intake. I tested them out in the NWM eval workflow, and they seem to be working.

Syndey - did you add that data to the `nhgf-development` bucket? I'm wondering if I can delete it now that it is moved, or if someone else put it there and we should leave it. I see that there is also a file `parquet_test` in the nwm folder - if we do delete the other files, can this one be deleted as well?