### PR TITLE
conus404_osn

### DIFF
--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -3,9 +3,15 @@ sources:
   conus404-drb-eval-tutorial-catalog:
     args:
       path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404-drb-eval-tutorial-catalog.yml'
-    description: 'Catalog for CONUS404 DRB tutorial intermdieate datasets'
+    description: 'Catalog for CONUS404 DRB tutorial intermediate datasets'
     driver: intake.catalog.local.YAMLFileCatalog
-  
+
+  conus404-catalog:
+    args:
+      path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404-catalog.yml'
+    description: 'Catalog for CONUS404 datasets'
+    driver: intake.catalog.local.YAMLFileCatalog
+   
   conus404-hourly-onprem:
     driver: zarr
     description: "CONUS404 Hydro Variable subset, 40 years of hourly data on Caldera on prem storage"

--- a/dataset_catalog/subcatalogs/conus404_catalog.yml
+++ b/dataset_catalog/subcatalogs/conus404_catalog.yml
@@ -14,10 +14,7 @@ sources:
       urlpath: 's3://nhgf-development/conus404/conus404_hourly_202209.zarr'
       consolidated: true
       storage_options:
-        anon: true
-        requester_pays: false
-        client_kwargs:
-          endpoint_url: https://renc.osn.xsede.org
+        requester_pays: true
 
   conus404-hourly-osn:
     driver: zarr
@@ -26,7 +23,10 @@ sources:
       urlpath: 's3://rsignellbucket2/hytest/conus404/conus404_hourly_202302.zarr'
       consolidated: true
       storage_options:
-        requester_pays: true
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://renc.osn.xsede.org
 
   conus404-daily-diagnostic-onprem:
     driver: zarr

--- a/dataset_catalog/subcatalogs/conus404_catalog.yml
+++ b/dataset_catalog/subcatalogs/conus404_catalog.yml
@@ -14,6 +14,18 @@ sources:
       urlpath: 's3://nhgf-development/conus404/conus404_hourly_202209.zarr'
       consolidated: true
       storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://renc.osn.xsede.org
+
+  conus404-hourly-osn:
+    driver: zarr
+    description: "CONUS404 Hydro Variable subset, 40 years of hourly values. These files were created wrfout model output files (see ScienceBase data release for more details: https://www.sciencebase.gov/catalog/item/6372cd09d34ed907bf6c6ab1). This dataset is stored on AWS S3 cloud storage in a requester-pays bucket. You can work with this data for free in any environment (there are no egress fees)."
+    args:
+      urlpath: 's3://rsignellbucket2/hytest/conus404/conus404_hourly_202302.zarr'
+      consolidated: true
+      storage_options:
         requester_pays: true
 
   conus404-daily-diagnostic-onprem:


### PR DESCRIPTION
I added the OSN copy of CONUS404 to the conus404-catalog and linked to the conus404-catalog from the main hytest catalog.

I did not delete the entries of CONUS404 from the main hytest catalog yet because I don't have time to scrape/update the notebooks catalog paths before I go on leave today. Feel free to merge this in, and I will make another PR next week to update any notebooks (unless someone else has time!).