### PR TITLE
update filepaths to point to new c404 intake catalog

### DIFF
--- a/apps/CONUS404_Panel_App.ipynb
+++ b/apps/CONUS404_Panel_App.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
    ]
   },
   {

--- a/apps/CONUS404_Panel_App.ipynb
+++ b/apps/CONUS404_Panel_App.ipynb
@@ -30,7 +30,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
    ]
   },
   {
@@ -39,7 +39,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog(url)\n",
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(url)\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
     "list(cat)"
    ]
   },

--- a/dataset_access/conus404_explore.ipynb
+++ b/dataset_access/conus404_explore.ipynb
@@ -72,6 +72,32 @@
   },
   {
    "cell_type": "code",
+   "execution_count": null,
+   "id": "067d1b7d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(\n",
+    "    r\"https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml\"\n",
+    ")\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "25db9324",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
+    "list(cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 2,
    "id": "c6d6c625-b5d7-4a17-ae2d-d7c2e8bc3fa6",
    "metadata": {},
@@ -101,9 +127,6 @@
     }
    ],
    "source": [
-    "cat = intake.open_catalog(\n",
-    "    r\"https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml\"\n",
-    ")\n",
     "## NOTE: we happen to know this dataset's handle/name.\n",
     "dataset = 'conus404-hourly-cloud' \n",
     "## If you did not know this name, you could list the datasets in the catalog with\n",

--- a/dataset_access/conus404_regrid.ipynb
+++ b/dataset_access/conus404_regrid.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
    ]
   },
   {
@@ -45,7 +45,19 @@
    },
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog(url)\n",
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(url)\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
     "list(cat)"
    ]
   },

--- a/dataset_access/conus404_regrid.ipynb
+++ b/dataset_access/conus404_regrid.ipynb
@@ -34,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
    ]
   },
   {

--- a/dataset_access/conus404_spatial_aggregation.ipynb
+++ b/dataset_access/conus404_spatial_aggregation.ipynb
@@ -220,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
    ]
   },
   {

--- a/dataset_access/conus404_spatial_aggregation.ipynb
+++ b/dataset_access/conus404_spatial_aggregation.ipynb
@@ -220,7 +220,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
    ]
   },
   {
@@ -230,7 +230,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog(url)\n",
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(url)\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "cb5d2ce6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
     "list(cat)"
    ]
   },

--- a/dataset_access/conus404_temporal_aggregation.ipynb
+++ b/dataset_access/conus404_temporal_aggregation.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
    ]
   },
   {
@@ -56,7 +56,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat = intake.open_catalog(url)\n",
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(url)\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2faf85aa",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
     "list(cat)"
    ]
   },

--- a/dataset_access/conus404_temporal_aggregation.ipynb
+++ b/dataset_access/conus404_temporal_aggregation.ipynb
@@ -46,7 +46,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'"
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'"
    ]
   },
   {

--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -11,70 +11,6 @@ sources:
       path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404-catalog.yml'
     description: 'Catalog for CONUS404 datasets'
     driver: intake.catalog.local.YAMLFileCatalog
-   
-  conus404-hourly-onprem:
-    driver: zarr
-    description: "CONUS404 Hydro Variable subset, 40 years of hourly data on Caldera on prem storage"
-    args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_hourly.zarr/'
-      consolidated: true      
-
-  conus404-hourly-cloud:
-    driver: zarr
-    description: "CONUS404 Hydro Variable subset, 40 years of hourly values on Cloud"
-    args:
-      urlpath: 's3://nhgf-development/conus404/conus404_hourly_202209.zarr'
-      consolidated: true
-      storage_options:
-        requester_pays: true
-        
-  conus404-daily-onprem:
-    driver: zarr
-    description: "CONUS404 40 years of daily values for subset of model output variables derived from hourly values on Caldera on-premise storage"
-    args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily.zarr/'
-      consolidated: true  
-
-  conus404-daily-diagnostic-onprem:
-    driver: zarr
-    description: "CONUS404 40 years of daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10) on Caldera on-premise storage"
-    args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily_xtrm.zarr/'
-      consolidated: true  
-
-  conus404-daily-cloud:
-    driver: zarr
-    description: "CONUS404 40 years of daily values for subset of model output variables derived from hourly values on cloud storage"
-    args:
-      urlpath: 's3://nhgf-development/conus404/conus404_daily_202210.zarr/'
-      consolidated: true
-      storage_options:
-        requester_pays: true
-
-  conus404-daily-diagnostic-cloud:
-    driver: zarr
-    description: "CONUS404 40 years of daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10) on cloud storage"
-    args:
-      urlpath: 's3://nhgf-development/conus404/conus404_daily.zarr/'
-      consolidated: true
-      storage_options:
-        requester_pays: true
-
-  conus404-monthly-onprem:
-    driver: zarr
-    description: "CONUS404 40 years of monthly values for subset of model output variables derived from daily values on Caldera on-premise storage"
-    args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_monthly.zarr'
-      consolidated: true  
-
-  conus404-monthly-cloud:
-    driver: zarr
-    description: "CONUS404 40 years of monthly values for subset of model output variables derived from daily values on cloud storage"
-    args:
-      urlpath: 's3://nhgf-development/conus404/conus404_monthly_202210.zarr'
-      consolidated: true
-      storage_options:
-        requester_pays: true
 
   nwis-streamflow-usgs-gages-onprem:
     driver: zarr
@@ -142,15 +78,6 @@ sources:
         remote_options:
           requester_pays: true
         remote_protocol: s3
-  
-  conus404-hourly-cloud-dev:
-    driver: zarr
-    description: "DEV -- CONUS404 Hydro Variable subset, 40 years of hourly values on Cloud.  Don't use for production"
-    args:
-      urlpath: 's3://nhgf-development/workspace/conus404_hourly_202209.zarr'
-      consolidated: true
-      storage_options:
-        requester_pays: true
 
   nhm-v1.0-daymet-byHRU-onprem:
     driver: intake_xarray.xzarr.ZarrSource

--- a/dataset_preprocessing/tutorials/CONUS404/1_CONUS404_DRB_Data_Prep.ipynb
+++ b/dataset_preprocessing/tutorials/CONUS404/1_CONUS404_DRB_Data_Prep.ipynb
@@ -148,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'\n",
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'\n",
     "cat = intake.open_catalog(url)\n",
     "list(cat)"
    ]

--- a/dataset_preprocessing/tutorials/CONUS404/1_CONUS404_DRB_Data_Prep.ipynb
+++ b/dataset_preprocessing/tutorials/CONUS404/1_CONUS404_DRB_Data_Prep.ipynb
@@ -148,8 +148,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404_catalog.yml'\n",
-    "cat = intake.open_catalog(url)\n",
+    "url = 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/hytest_intake_catalog.yml'\n",
+    "# open the hytest data intake catalog\n",
+    "hytest_cat = intake.open_catalog(url)\n",
+    "list(hytest_cat)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# open the conus404 sub-catalog\n",
+    "cat = hytest_cat['conus404-catalog']\n",
     "list(cat)"
    ]
   },

--- a/essential_reading/Demoing_Commonly_Used_Libraries.ipynb
+++ b/essential_reading/Demoing_Commonly_Used_Libraries.ipynb
@@ -329,7 +329,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cat['conus404-hourly-cloud']"
+    "conus404_cat = cat[\"conus404_catalog\"]\n",
+    "conus404_cat['conus404-hourly-cloud']"
    ]
   },
   {


### PR DESCRIPTION
This PR (1) updates all notebooks to point to conus404 subcatalog and (2) deletes all conus404 entries from the main hytest intake catalog.

I deleted `conus404-hourly-cloud-dev` altogether - it was pointing to `s3://nhgf-development/workspace/conus404_hourly_202209.zarr` - I'm not sure why it was in the catalog - do we need it? @rsignell-usgs 