### PR TITLE
Update JB TOC

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,13 +7,19 @@ copyright: '2023'
 description: Training materials for HyTEST workflows.
 thumbnail: doc/assets/HyTEST_Badge.svg
 exclude_patterns : [_build, Thumbs.db, .github, .DS_Store, "**.ipynb_checkpoints", "*.zarr", .pytest_cache]
-only_build_toc_files: True 
+only_build_toc_files: True
 
 # Execute the notebooks upon build
 execute:
   execute_notebooks: cache
   timeout: 600
   allow_errors: True
+  ## Some notebooks demonstrate workflows for non-nebari systems; but we build on nebari, so these noteboooks are excluded from execution.
+  exclude_patterns: [
+    environment_set_up/Start_Dask_Cluster_Denali.ipynb,
+    environment_set_up/Start_Dask_Cluster_PangeoCHS.ipynb,
+    environment_set_up/Start_Dask_Cluster_Tallgrass.ipynb
+    ]
 
 # Add a few extensions to help with parsing content
 parse:

--- a/_toc.yml
+++ b/_toc.yml
@@ -1,5 +1,5 @@
 format: jb-book
-root: README
+root: doc/About
 
 parts:
   - caption: Environment Set-Up

--- a/_toc.yml
+++ b/_toc.yml
@@ -37,12 +37,17 @@ parts:
       - file: dataset_preprocessing/ReChunkingData
       - file: dataset_preprocessing/ReChunkingData_Cloud
 
-
   - caption: Dataset Access
     chapters:
     - file: dataset_catalog/README
-    - file: dataset_catalog/subcatalogs/README
-
+      sections: 
+        - file: dataset_catalog/subcatalogs/README
+    - file: dataset_access/README
+      sections: 
+        - file: dataset_access/conus404_explore
+        - file: dataset_access/conus404_temporal_aggregation
+        - file: dataset_access/conus404_spatial_aggregation
+        - file: dataset_access/conus404_regrid
    
   - caption: Model Evaluation Tutorials
     chapters:

--- a/_toc.yml
+++ b/_toc.yml
@@ -21,13 +21,17 @@ parts:
    
   - caption: Getting Started
     chapters:
+    - file: essential_reading/README
     - file: essential_reading/ReadingsTutorials
+    - file: essential_reading/Demoing_Commonly_Used_Libraries
     - file: essential_reading/DataSources/README
       sections: 
       - file: essential_reading/DataSources/Data_APIs
       - file: essential_reading/DataSources/Data_S3
       - file: essential_reading/DataSources/Data_STAC
     - file: essential_reading/Parallel_Dask
+
+  - caption: Dataset Preprocessing
     - file: dataset_preprocessing/chunk
       sections: 
       - file: dataset_preprocessing/ReChunkingData

--- a/_toc.yml
+++ b/_toc.yml
@@ -15,9 +15,9 @@ parts:
       sections:
       - file: environment_set_up/Help_AWS_Credentials
       - file: environment_set_up/Start_Dask_Cluster_Nebari  
-      #- file: environment_set_up/Start_Dask_Cluster_PangeoCHS
+      - file: environment_set_up/Start_Dask_Cluster_PangeoCHS
       - file: environment_set_up/Start_Dask_Cluster_Denali
-      #- file: environment_set_up/Start_Dask_Cluster_Tallgrass
+      - file: environment_set_up/Start_Dask_Cluster_Tallgrass
    
   - caption: Getting Started
     chapters:

--- a/_toc.yml
+++ b/_toc.yml
@@ -5,7 +5,7 @@ parts:
   - caption: Environment Set-Up
     chapters:
     - file: environment_set_up/README
-      sections: 
+      sections:
       - file: environment_set_up/QuickStart-Cloud-Nebari
       - file: environment_set_up/QuickStart-Cloud-pangeoCHS
       - file: environment_set_up/OpenOnDemand
@@ -14,41 +14,42 @@ parts:
     - file: environment_set_up/clusters
       sections:
       - file: environment_set_up/Help_AWS_Credentials
-      - file: environment_set_up/Start_Dask_Cluster_Nebari  
-      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_PangeoCHS
-      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_Denali
-      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_Tallgrass
-   
+      - file: environment_set_up/Start_Dask_Cluster_Nebari
+      - file: environment_set_up/Start_Dask_Cluster_PangeoCHS
+      - file: environment_set_up/Start_Dask_Cluster_Denali
+      - file: environment_set_up/Start_Dask_Cluster_Tallgrass
+
   - caption: Getting Started
     chapters:
     - file: essential_reading/README
     - file: essential_reading/ReadingsTutorials
     - file: essential_reading/Demoing_Commonly_Used_Libraries
     - file: essential_reading/DataSources/README
-      sections: 
+      sections:
       - file: essential_reading/DataSources/Data_APIs
       - file: essential_reading/DataSources/Data_S3
       - file: essential_reading/DataSources/Data_STAC
     - file: essential_reading/Parallel_Dask
 
   - caption: Dataset Preprocessing
+    chapters:
     - file: dataset_preprocessing/chunk
-      sections: 
+      sections:
       - file: dataset_preprocessing/ReChunkingData
       - file: dataset_preprocessing/ReChunkingData_Cloud
 
   - caption: Dataset Access
     chapters:
     - file: dataset_catalog/README
-      sections: 
+      sections:
         - file: dataset_catalog/subcatalogs/README
     - file: dataset_access/README
-      sections: 
+      sections:
         - file: dataset_access/conus404_explore
         - file: dataset_access/conus404_temporal_aggregation
         - file: dataset_access/conus404_spatial_aggregation
         - file: dataset_access/conus404_regrid
-   
+
   - caption: Model Evaluation Tutorials
     chapters:
     - file: evaluation/README

--- a/_toc.yml
+++ b/_toc.yml
@@ -46,6 +46,7 @@ parts:
    
   - caption: Model Evaluation Tutorials
     chapters:
+    - file: evaluation/README
     - file: evaluation/metrics
       sections:
       - file: evaluation/Metrics_DScore_Suite_v1

--- a/_toc.yml
+++ b/_toc.yml
@@ -15,9 +15,9 @@ parts:
       sections:
       - file: environment_set_up/Help_AWS_Credentials
       - file: environment_set_up/Start_Dask_Cluster_Nebari  
-      - file: environment_set_up/Start_Dask_Cluster_PangeoCHS
-      - file: environment_set_up/Start_Dask_Cluster_Denali
-      - file: environment_set_up/Start_Dask_Cluster_Tallgrass
+      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_PangeoCHS
+      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_Denali
+      - file: environment_set_up/jupyterbook_cluster_helper_md/Start_Dask_Cluster_Tallgrass
    
   - caption: Getting Started
     chapters:


### PR DESCRIPTION
This PR closes #266 - changes made:
- uncomment pangeoCHS and tallgrass helpers
- adds in Demoing_Commonly_Used_Libraries
- turns dataset preprocessing/rechunking into is own chapter
- add in CONUS404 exploration material
- adds in eval readme

Problems to resolve :
- need to add About to TOC - update: done
- TOC points to `environment_set_up/README`, `essential_reading/README`, and `evaluation/README`. These are meant to provide an overview of the type of content for the whole chapter. All of these contain links to the hytest repo that we probably actually want to point to the chapter. We could make a JB-specific copy of these which will have similar information, but be tailored to the JB style and link to those chapters? I will open an issue on this.

Follow up tasks (Amelia will create tasks for these):
- Amelia to test building JB to make sure instructions are clear
- Thorough review of JB contents by all team members to make sure everything flows well