### PR TITLE
remove link to HPC quickstart that was removed

### DIFF
--- a/environment_set_up/StartScript.md
+++ b/environment_set_up/StartScript.md
@@ -21,5 +21,4 @@ is built using [this](./HyTEST.yml) environment definition. We recommend that yo
 use it as the baseline if you will be building your own environment.
 
 If you choose to do that, you will want to edit the `jupyter-start.sh` script to reflect
-the particulars of your custom conda environment.  See [here](./QuickStart-HPC.md) for
-an example walk-through of that process.
+the particulars of your custom conda environment.


### PR DESCRIPTION
This doc was removed, and I didn't see any other relevant resource to point to. The editing that needs to be done seem clear in the start script. Are we ok to just remove this sentence?