### PR TITLE
Add notebook to remove variables from zmetadata files

### DIFF
--- a/dataset_preprocessing/archive/conus404_raw/conus404_raw_remove_derived_variables/zarr_metadata_edit.ipynb
+++ b/dataset_preprocessing/archive/conus404_raw/conus404_raw_remove_derived_variables/zarr_metadata_edit.ipynb
@@ -1,0 +1,160 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42876735-f2cc-4c50-a94f-3d9a7b37e5f2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "from zarr.util import NumberEncoder"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "579decc4-e544-4fa8-8bc4-8452b3f86ffb",
+   "metadata": {},
+   "source": [
+    "# Remove variables from Zarr metadata file\n",
+    "This notebook removes variable entries from a `.zmetadata` file in a Zarr store. The actual data will still exist but the variables\n",
+    "will not show up in the dataset.\n",
+    "\n",
+    "Can use `diff --ignore-all-space --suppress-common-lines -s -y <file1> <file2>` to compare the new metadata file to old."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "772afe6f-41c4-4e93-9538-3c6d9b44a282",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "base_json_out_dir = '/caldera/projects/usgs/water/wbeep/conus404_work/00_zarr_json_backups'\n",
+    "base_zarr_dir = '/caldera/hytest_scratch/scratch/conus404'\n",
+    "\n",
+    "interval = 'monthly'   # one of: hourly, daily, monthly\n",
+    "\n",
+    "src_filename = f'{base_zarr_dir}/conus404_{interval}.zarr/.zmetadata'\n",
+    "dst_filename = f'{base_json_out_dir}/20231120_zmetadata_backups/20231120_c404_{interval}_derived_vars_removal/zmetadata.new'\n",
+    "\n",
+    "# List of variables to remove\n",
+    "remove_vars = ['E2', 'ES2', 'RH2', 'SH2']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "be858fb4-608a-43bf-9e27-0cb62bba2f1f",
+   "metadata": {},
+   "source": [
+    "## Load the `.zmetadata` json file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bb3568f-cc7b-427b-b2e5-85fc896a191b",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with open(src_filename, 'r') as in_hdl:\n",
+    "    data = json.load(in_hdl)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7164cea8-0d47-4c9e-bbc4-9d2f07c8bb2c",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "## Remove variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "905a9bda-0791-4862-b820-c8f4bf948fcc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "for vv in remove_vars:\n",
+    "    print(f'Removing {vv}')\n",
+    "    del data['metadata'][f'{vv}/.zarray']\n",
+    "    del data['metadata'][f'{vv}/.zattrs']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "00d73688-d4a2-4f0d-b704-05140a70d73b",
+   "metadata": {},
+   "source": [
+    "## Write json to a file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "acb9eead-758c-44ae-bdd2-7bd695cee8f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(dst_filename, 'w') as out_hdl:\n",
+    "    json.dump(data, out_hdl, indent=4, sort_keys=True, ensure_ascii=True, separators=(',', ': '), cls=NumberEncoder)\n",
+    "    \n",
+    "print(f'Updated zmetadata file written to: {dst_filename}')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a211f940-569e-47b2-ad5c-f137c8b33ff6",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# Pretty print the JSON string\n",
+    "# print(json.dumps(data, indent = 4, sort_keys=False))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b722b438-60b1-4747-90c1-1e62ad6f59c0",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:pangeo]",
+   "language": "python",
+   "name": "conda-env-pangeo-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This adds a notebook which reads the zmetadata file for a zarr store and removes selected variables before writing a new zmetadata file. This addresses #386 

Copies of the original and new zmetadata files are stored on caldera.