### PR TITLE
update onprem paths to point to hovenweep

### DIFF
--- a/dataset_catalog/subcatalogs/conus404-catalog.yml
+++ b/dataset_catalog/subcatalogs/conus404-catalog.yml
@@ -4,7 +4,7 @@ sources:
     driver: zarr
     description: "CONUS404 Hydro Variable subset, 40 years of hourly data on Caldera. These files were created wrfout model output files (see ScienceBase data release for more details: https://www.sciencebase.gov/catalog/item/6372cd09d34ed907bf6c6ab1). This dataset is stored on USGS on-premise Caldera storage and is only accessible through USGS on-premise computing resources."
     args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_hourly.zarr/'
+      urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/conus404/conus404_hourly.zarr'
       consolidated: true      
 
   conus404-hourly-cloud:
@@ -32,7 +32,7 @@ sources:
     driver: zarr
     description: "CONUS404 40 years of daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10). These files were created wrfxtrm model output files (see ScienceBase data release for more details: https://www.sciencebase.gov/catalog/item/6372cd09d34ed907bf6c6ab1). This dataset is stored on USGS on-premise Caldera storage and is only accessible through USGS on-premise computing resources."
     args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily_xtrm.zarr/'
+      urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/conus404/conus404_daily_xtrm.zarr'
       consolidated: true  
 
   conus404-daily-diagnostic-cloud:
@@ -60,7 +60,7 @@ sources:
     driver: zarr
     description: "CONUS404 40 years of daily values for subset of model output variables derived from hourly values. This dataset is stored on USGS on-premise Caldera storage and is only accessible through USGS on-premise computing resources."
     args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_daily.zarr/'
+      urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/conus404/conus404_daily.zarr'
       consolidated: true  
 
   conus404-daily-cloud:
@@ -88,7 +88,7 @@ sources:
     driver: zarr
     description: "CONUS404 40 years of monthly values for subset of model output variables derived from daily values. This dataset is stored on USGS on-premise Caldera storage and is only accessible through USGS on-premise computing resources."
     args:
-      urlpath: '/caldera/hytest_scratch/scratch/conus404/conus404_monthly.zarr'
+      urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/conus404/conus404_monthly.zarr'
       consolidated: true  
 
   conus404-monthly-cloud:

--- a/dataset_catalog/subcatalogs/nhm-v1.0-daymet-catalog.yml
+++ b/dataset_catalog/subcatalogs/nhm-v1.0-daymet-catalog.yml
@@ -7,7 +7,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.0/dm_byHRU/nhm_v1.0_dm_byHRU_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU/nhm_v1.0_dm_byHRU_combined.json'
 
   nhm-v1.0-daymet-byHW-musk-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -16,7 +16,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.0/dm_byHRU_musk/nhm_v1.0_dm_byHRU_musk_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU_musk/nhm_v1.0_dm_byHRU_musk_combined.json'
 
   nhm-v1.0-daymet-byHW-musk-obs-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -25,7 +25,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.0/dm_byHRU_musk_obs/nhm_v1.0_dm_byHRU_musk_obs_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU_musk_obs/nhm_v1.0_dm_byHRU_musk_obs_combined.json'
 
   nhm-v1.0-daymet-byHW-noroute-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -34,7 +34,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.0/dm_byHRU_noroute/nhm_v1.0_dm_byHRU_noroute_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU_noroute/nhm_v1.0_dm_byHRU_noroute_combined.json'
 
   nhm-v1.0-daymet-byHW-noroute_obs-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -43,4 +43,4 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.0/dm_byHRU_noroute_obs/nhm_v1.0_dm_byHRU_noroute_obs_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU_noroute_obs/nhm_v1.0_dm_byHRU_noroute_obs_combined.json'

--- a/dataset_catalog/subcatalogs/nhm-v1.1-c404-bc-catalog.yml
+++ b/dataset_catalog/subcatalogs/nhm-v1.1-c404-bc-catalog.yml
@@ -7,7 +7,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/c404-bc_byHRU/nhm_v1.1_c404-bc_byHRU_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/c404-bc_byHRU/nhm_v1.1_c404-bc_byHRU_combined.json'
 
   nhm-v1.1-c404-bc-byHW-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -16,7 +16,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/c404-bc_byHW/nhm_v1.1_c404-bc_byHW_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/c404-bc_byHW/nhm_v1.1_c404-bc_byHW_combined.json'
 
   nhm-v1.1-c404-bc-byHWobs-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -25,4 +25,4 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/c404-bc_byHWobs/nhm_v1.1_c404-bc_byHWobs_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/c404-bc_byHWobs/nhm_v1.1_c404-bc_byHWobs_combined.json'

--- a/dataset_catalog/subcatalogs/nhm-v1.1-gridmet-catalog.yml
+++ b/dataset_catalog/subcatalogs/nhm-v1.1-gridmet-catalog.yml
@@ -7,7 +7,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/gm_byHRU/nhm_v1.1_gm_byHRU_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/gm_byHRU/nhm_v1.1_gm_byHRU_combined.json'
 
   nhm-v1.1-gridmet-byHW-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -16,7 +16,7 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/gm_byHW/nhm_v1.1_gm_byHW_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/gm_byHW/nhm_v1.1_gm_byHW_combined.json'
 
   nhm-v1.1-gridmet-byHWobs-onprem:
     driver: intake_xarray.xzarr.ZarrSource
@@ -25,4 +25,4 @@ sources:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
-        fo: '/caldera/hytest_scratch/scratch/nhm/nhm_v1.1/gm_byHWobs/nhm_v1.1_gm_byHWobs_combined.json'
+        fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.1/gm_byHWobs/nhm_v1.1_gm_byHWobs_combined.json'


### PR DESCRIPTION
FYI - updating our intake catalogs to point to Hovenweep now. Let me know if updating these will break anything for you.