### PR TITLE
Make PGW entries not duplicates

### DIFF
--- a/dataset_catalog/subcatalogs/README.md
+++ b/dataset_catalog/subcatalogs/README.md
@@ -63,8 +63,8 @@ producing a list of all the CONUS404 dataset versions:
  'conus404-daily-ba-osn',
  'conus404-pgw-hourly-onprem-hw',
  'conus404-pgw-hourly-osn',
- 'conus404-daily-diagnostic-onprem-hw',
- 'conus404-daily-diagnostic-osn']
+ 'conus404-pgw-daily-diagnostic-onprem-hw',
+ 'conus404-pgw-daily-diagnostic-osn']
 ```
 
 The characteristics of indivdual datasets can be explored:

--- a/dataset_catalog/subcatalogs/conus404-catalog.yml
+++ b/dataset_catalog/subcatalogs/conus404-catalog.yml
@@ -170,14 +170,14 @@ sources:
         client_kwargs:
           endpoint_url: https://usgs.osn.mghpcc.org/
 
-  conus404-daily-diagnostic-onprem-hw:
+  conus404-pgw-daily-diagnostic-onprem-hw:
     driver: zarr
     description: "CONUS404 pseudo-global warming (PGW) daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10). These files were created wrfxtrm model output files (see ScienceBase data release for more details: https://doi.org/10.5066/P9HH85UU). This dataset is stored on USGS on-premise Caldera storage for Hovenweep and is only accessible via the USGS Hovenweep supercomputer."
     args:
       urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/conus404-pgw/conus404-pgw_xtrm_daily.zarr'
       consolidated: true  
 
-  conus404-daily-diagnostic-osn:
+  conus404-pgw-daily-diagnostic-osn:
     driver: zarr
     description: "CONUS404 pseudo-global warming (PGW) daily diagnostic output (maximum, minimum, mean, and standard deviation) for water vapor (Q2), grid-scale precipitation (RAINNC), skin temperature (SKINTEMP), wind speed at 10 meter height (SPDUV10), temperature at 2 meter height (T2), and U- and V-component of wind at 10 meters with respect to model grid (U10, V10). These files were created wrfxtrm model output files (see ScienceBase data release for more details: https://doi.org/10.5066/P9HH85UU). This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
     args:


### PR DESCRIPTION
# Pull Request Code Review

## Overview

The new daily diagnostic CONUS404 PGW entries in the CONUS404 intake catalog were duplicate names. Intake catalogs must have unique names. This makes the names unique.

## Summary of Changes

- Changes the conus404-catalog.yml and associated README with new entry names.