### PR TITLE
add streamflow benchmarks to intake catalog

### DIFF
--- a/dataset_catalog/hytest_intake_catalog.yml
+++ b/dataset_catalog/hytest_intake_catalog.yml
@@ -5,7 +5,13 @@ sources:
       path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404-catalog.yml'
     description: 'Catalog for CONUS404 datasets'
     driver: intake.catalog.local.YAMLFileCatalog
-    
+
+  benchmarks-catalog:
+    args:
+      path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/benchmarks-catalog.yml'
+    description: 'Catalog for model benchmarking datasets'
+    driver: intake.catalog.local.YAMLFileCatalog
+        
   conus404-drb-eval-tutorial-catalog:
     args:
       path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/conus404-drb-eval-tutorial-catalog.yml'

--- a/dataset_catalog/subcatalogs/benchmarks-catalog.yml
+++ b/dataset_catalog/subcatalogs/benchmarks-catalog.yml
@@ -1,0 +1,6 @@
+sources:
+  streamflow-benchmarks-catalog:
+    args:
+      path: 'https://raw.githubusercontent.com/hytest-org/hytest/main/dataset_catalog/subcatalogs/streamflow-benchmarks-catalog.yml'
+    description: 'Catalog for streamflow model benchmarking datasets'
+    driver: intake.catalog.local.YAMLFileCatalog

--- a/dataset_catalog/subcatalogs/streamflow-benchmarks-catalog.yml
+++ b/dataset_catalog/subcatalogs/streamflow-benchmarks-catalog.yml
@@ -1,0 +1,67 @@
+sources:
+
+  nhmv1-standardsuite-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by the standard statistical suite (v1.0) for the National Hydrologic Model application of the Precipitation-Runoff Modeling System (v1 byObs Muskingum) at benchmark streamflow locations in the conterminous United States (ver 3.0, March 2023). See ScienceBase data release for more details: https://doi.org/10.5066/P9DKA9KQ. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nhmv1/standard_suite_v1_nhmv1_V2.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nhmv1-standardsuite-KGE-uncertainty-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by the standard statistical suite (v1.0) for the National Hydrologic Model application of the Precipitation-Runoff Modeling System (v1 byObs Muskingum) at benchmark streamflow locations in the conterminous United States (ver 3.0, March 2023) - KGE Uncertainty. See ScienceBase data release for more details: https://doi.org/10.5066/P9DKA9KQ. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nhmv1/KGE_gumbootStats_nhmv1.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nhmv1-dscore-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by D-score (v0.1) for the National Hydrologic Model application of the Precipitation-Runoff Modeling System (v1 byObs Muskingum) at benchmark streamflow locations. See ScienceBase data release for more details: https://doi.org/10.5066/P9PZLHYZ. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nhmv1/streamflow_nhm_v1_byObs_musk-dscore_v0.1-benchmark_v1.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nwm2d1-standardsuite-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by the standard statistical suite (v1.0) for the National Water Model Retrospective (v2.1) at benchmark streamflow locations for the conterminous United States (ver 3.0, March 2023). See ScienceBase data release for more details: https://doi.org/10.5066/P9QT1KV7. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nwmv2d1/standard_suite_v1_nwmv2d1_V2.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nwm2d1-standardsuite-KGE-uncertainty-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by the standard statistical suite (v1.0) for the National Water Model Retrospective (v2.1) at benchmark streamflow locations for the conterminous United States (ver 3.0, March 2023) - KGE Uncertainty. See ScienceBase data release for more details: https://doi.org/10.5066/P9QT1KV7. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nwmv2d1/KGE_gumbootStats_nwmv21.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nwm2d1-dscore-osn:
+    driver: csv
+    description: "Daily streamflow performance benchmark defined by D-score (v0.1) for the National Water Model Retrospective (v2.1) at benchmark streamflow locations. See ScienceBase data release for more details: https://doi.org/10.5066/P9MJDNRL. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/benchmarks/streamflow/nwmv2d1/streamflow_nwm_v2.1-dscore_v0.1-benchmark_v1.csv'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/


### PR DESCRIPTION
I added benchmarking results to the OSN pod and made a new benchmarks subcatalog in our intake catalog. I also created a streamflow subcatalog in the benchmarks catalog so that we can have subcatalogs by variable as we benchmark more variables.

Please review for catalog structure and to verify content is correct.