### PR TITLE
add example OSN kerchunk entry and links to poi nc files

### DIFF
--- a/dataset_catalog/subcatalogs/nhm-v1.0-daymet-catalog.yml
+++ b/dataset_catalog/subcatalogs/nhm-v1.0-daymet-catalog.yml
@@ -1,13 +1,50 @@
 sources:
 
+  nhm-v1.0-daymet-byHRU-osn:
+    driver: intake_xarray.xzarr.ZarrSource
+    description: "National Hydrologic Model version 1.0 model output (see ScienceBase data release for more details: https://doi.org/10.5066/P9PGZE0S) variables using byHRU calibrated parameters with Daymet version 3 forcings. This dataset is stored on USGS on-premise Caldera storage for Hovenweep and is only accessible via the USGS Hovenweep supercomputer."
+    args:
+      urlpath: 'reference://'
+      consolidated: false
+      storage_options:
+        fo: 'https://usgs.osn.mghpcc.org/hytest/nhm/nhm_v1.0/dm_byHRU/nhm_v1.0_dm_byHRU_combined.json'
+        remote_protocol: 's3'
+        remote_options: 
+          anon: true
+          client_kwargs:
+            endpoint_url: https://usgs.osn.mghpcc.org/
+
+  nhm-v1.0-daymet-byHRU-poi-summary-osn:
+    driver: netcdf
+    description: "National Hydrologic Model version 1.0 model output - simulated streamflow and statistics at streamgages (see ScienceBase data release for more details: https://doi.org/10.5066/P9PGZE0S) variables using byHRU calibrated parameters with Daymet version 3 forcings. This data is stored on HyTEST’s Open Storage Network (OSN) pod. This data can be read with the S3 API and is free to work with in any computing environment (there are no egress fees)."
+    args:
+      urlpath: 's3://hytest/nhm/nhm_v1.0/dm_byHRU/NHM-PRMS_data_release.nc'
+      storage_options:
+        anon: true
+        requester_pays: false
+        client_kwargs:
+          endpoint_url: https://usgs.osn.mghpcc.org/
+      chunks: {}
+      xarray_kwargs:
+        engine: h5netcdf
+
   nhm-v1.0-daymet-byHRU-onprem-hw:
     driver: intake_xarray.xzarr.ZarrSource
-    description: "National Hydrologic Model version 1.0 model output variables using byHRU calibrated parameters with Daymet version 3 forcings. This dataset is stored on USGS on-premise Caldera storage for Hovenweep and is only accessible via the USGS Hovenweep supercomputer."
+    description: "National Hydrologic Model version 1.0 model output (see ScienceBase data release for more details: https://doi.org/10.5066/P9PGZE0S) variables using byHRU calibrated parameters with Daymet version 3 forcings. This dataset is stored on USGS on-premise Caldera storage for Hovenweep and is only accessible via the USGS Hovenweep supercomputer."
     args:
       urlpath: 'reference://'
       consolidated: false
       storage_options:
         fo: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU/nhm_v1.0_dm_byHRU_combined.json'
+
+  nhm-v1.0-daymet-byHRU-poi-summary-onprem-hw:
+    driver: netcdf
+    description: "National Hydrologic Model version 1.0 model output - simulated streamflow and statistics at streamgages (see ScienceBase data release for more details: https://doi.org/10.5066/P9PGZE0S) variables using byHRU calibrated parameters with Daymet version 3 forcings. This dataset is stored on USGS on-premise Caldera storage for Hovenweep and is only accessible via the USGS Hovenweep supercomputer."
+    args:
+      urlpath: '/caldera/hovenweep/projects/usgs/water/impd/hytest/nhm/nhm_v1.0/dm_byHRU/NHM-PRMS_data_release.nc'
+      chunks: {}
+      xarray_kwargs:
+        engine: h5netcdf
 
   nhm-v1.0-daymet-byHW-musk-onprem-hw:
     driver: intake_xarray.xzarr.ZarrSource


### PR DESCRIPTION
@pnorton-usgs - I'm planning to update the nhm intake catalogs to include a copy of the NHM output that i've uploaded to the OSN pod.

I am also suggesting that we add a catalog entry for the POI model output because I know some folks are using it and would like it to be catalogged.

I've added one example of the files on the OSN pod, and an addition to point to the POI file on howenweep.

Can you let me know if this plan sounds good?

And can you check the kerchunk json I created for the OSN pod and let me know if everything seems good? You can open it by checking out this branch, and running:
```
cat = intake.open_catalog("../../dataset_catalog/subcatalogs/nhm-v1.0-daymet-catalog.yml")

# for the kerchunk model output data:
dataset = 'nhm-v1.0-daymet-byHRU-osn'
# for the poi nc data:
#dataset = 'nhm-v1.0-daymet-byHRU-poi-summary-osn'

ds = cat[dataset].to_dask()
ds
```
